### PR TITLE
Fix palette bug when image file has less than the expected number of colours

### DIFF
--- a/coilsnake/model/eb/palettes.py
+++ b/coilsnake/model/eb/palettes.py
@@ -20,10 +20,7 @@ class EbColor(EqualityMixin, StringRepresentationMixin):
             self.r = self.g = self.b = 0
             self.used = False
         else:
-            self.r = r
-            self.g = g
-            self.b = b
-            self.used = True
+            self.from_tuple((r, g, b))
 
     def __eq__(self, other):
         return ((self.r == other.r)
@@ -52,16 +49,16 @@ class EbColor(EqualityMixin, StringRepresentationMixin):
 
     def from_tuple(self, rgb):
         self.used = True
-        self.r, self.g, self.b = rgb
+        self.r, self.g, self.b = (val & 0xf8 for val in rgb)
 
     def tuple(self):
         return self.r, self.g, self.b
 
     def from_list(self, rgb_list, offset=0):
-        self.used = True
-        self.r = rgb_list[offset] & 0xf8
-        self.g = rgb_list[offset + 1] & 0xf8
-        self.b = rgb_list[offset + 2] & 0xf8
+        rgbs = rgb_list[offset:offset+3]
+        if not rgbs:
+            rgbs = (0, 0, 0)
+        self.from_tuple(rgbs)
 
     def to_list(self, rgb_list, offset=0):
         rgb_list[offset] = self.r


### PR DESCRIPTION
Previously, when getting the palette from an image file with less than the expected number of colours, CoilSnake would raise an IndexError due to indexing outside the bounds of the palette array. Now, we will substitute in (0,0,0) instead.

Additionally, the palette class was refactored to avoid code duplication.