### PR TITLE
Fix issue when patching with Py3.9 and newer

### DIFF
--- a/coilsnake/model/eb/blocks.py
+++ b/coilsnake/model/eb/blocks.py
@@ -90,4 +90,4 @@ class EbRom(Rom):
         """Calculates the MD5 hash of this ROM's data.
         """
 
-        return hashlib.md5(self.data.tostring()).hexdigest()
+        return hashlib.md5(self.data.tobytes()).hexdigest()


### PR DESCRIPTION
`array.tostring()` was deprecated in Python 3.2 and removed in Python 3.9 - we should use `tobytes()` instead.
See https://docs.python.org/3.8/library/array.html#array.array.tostring