### PR TITLE
Window location fix

### DIFF
--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -184,6 +184,7 @@ class CoilSnakeGui(object):
             self.root.update_idletasks()
             xpos -= (self.root.winfo_x() - 100)
             ypos -= (self.root.winfo_y() - 100)
+
         self.root.geometry('{}x{}+{}+{}'.format(width, height, xpos, ypos))
         self.root.update_idletasks()
 

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -174,6 +174,15 @@ class CoilSnakeGui(object):
         height = self.preferences['height'] or self.root.winfo_height()
         xpos   = self.preferences['xpos']   or self.root.winfo_x()
         ypos   = self.preferences['ypos']   or self.root.winfo_y()
+
+        if platform.system() != "Windows" and platform.system() != "Darwin":
+            # Workaround - On X11, the window coordinates refer to the window border rather than the content
+            # Move the window to 100,100 and then measure where we ended up, to know how much to adjust by.
+            # This seems to exactly restore the window location on my machine.
+            self.root.geometry('{}x{}+100+100'.format(width, height))
+            self.root.update_idletasks()
+            xpos -= (self.root.winfo_x() - 100)
+            ypos -= (self.root.winfo_y() - 100)
         self.root.geometry('{}x{}+{}+{}'.format(width, height, xpos, ypos))
         self.root.update_idletasks()
 

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -163,8 +163,8 @@ class CoilSnakeGui(object):
     def save_geometry_and_close(self, e=None):
         self.preferences['width']  = self.root.winfo_width()
         self.preferences['height'] = self.root.winfo_height()
-        self.preferences['xpos']   = self.root.winfo_rootx()
-        self.preferences['ypos']   = self.root.winfo_rooty()
+        self.preferences['xpos']   = self.root.winfo_x()
+        self.preferences['ypos']   = self.root.winfo_y()
         self.preferences.save()
         self.root.destroy()
 
@@ -172,16 +172,8 @@ class CoilSnakeGui(object):
         self.root.update_idletasks()
         width  = self.preferences['width']  or self.root.winfo_width()
         height = self.preferences['height'] or self.root.winfo_height()
-        xpos   = self.preferences['xpos']   or self.root.winfo_rootx()
-        ypos   = self.preferences['ypos']   or self.root.winfo_rooty()
-
-        if platform.system() != "Windows" and platform.system() != "Darwin":
-            # Workaround - On X11, the window coordinates refer to the window border rather than the content
-            self.root.geometry('{}x{}+0+0'.format(width, height))
-            self.root.update_idletasks()
-            xpos -= self.root.winfo_rootx()
-            ypos -= self.root.winfo_rooty()
-
+        xpos   = self.preferences['xpos']   or self.root.winfo_x()
+        ypos   = self.preferences['ypos']   or self.root.winfo_y()
         self.root.geometry('{}x{}+{}+{}'.format(width, height, xpos, ypos))
         self.root.update_idletasks()
 

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -177,7 +177,8 @@ class CoilSnakeGui(object):
 
         if platform.system() != "Windows" and platform.system() != "Darwin":
             # Workaround - On X11, the window coordinates refer to the window border rather than the content
-            # Move the window to 100,100 and then measure where we ended up, to know how much to adjust by.
+            # Since there may be a menubar at the top of the screen, move the window to 100, 100 and
+            # then measure the position, to know how much we need to compensate our position by.
             # This seems to exactly restore the window location on my machine.
             self.root.geometry('{}x{}+100+100'.format(width, height))
             self.root.update_idletasks()


### PR DESCRIPTION
This change should make the window location restoring feature more consistent. On Windows, the window would shift a small amount on every startup, due to differences between the location being set by the `geometry` function, vs. the location read using the `winfo_rootx/winfo_rooty` functions. Using `winfo_x/winfo_y` instead seems to give correct results.

Additionally, when I tested on Linux, the window would also shift on every startup. I ended up finding out that this was due to the location being set to 0,0 and then the window being shifted down by my menubar - as a result, every time I started the program it would shift the window up to compensate for it being moved down (`ypos -= self.root.winfo_rooty()` would shift the window's Y position up by the height of my menubar). Now, we move the window to 100,100 instead of 0,0 in order to determine the difference between where `geometry()` is putting us vs. the actual position recorded.