### PR TITLE
Refactor ROM type strings + fix Block-related compilation failure

### DIFF
--- a/coilsnake/model/common/blocks.py
+++ b/coilsnake/model/common/blocks.py
@@ -316,7 +316,9 @@ with open_asset("romtypes.yml") as f:
     ROM_TYPE_MAP = yml_load(f)
 
 ROM_TYPE_NAME_UNKNOWN = "Unknown"
-
+ROM_TYPE_NAME_EARTHBOUND = "Earthbound"
+ROM_TYPE_NAME_EARTHBOUND_ZERO = "Earthbound Zero"
+ROM_TYPE_NAME_SUPER_MARIO_BROS = "Super Mario Bros"
 
 class Rom(AllocatableBlock):
     def reset(self, size=0):
@@ -392,7 +394,7 @@ class Rom(AllocatableBlock):
             return ROM_TYPE_NAME_UNKNOWN
 
     def add_header(self):
-        if self.type == 'Earthbound':
+        if self.type == ROM_TYPE_NAME_EARTHBOUND:
             for i in range(0x200):
                 self.data.insert(0, 0)
             self.size += 0x200
@@ -400,7 +402,7 @@ class Rom(AllocatableBlock):
             raise NotImplementedError("Don't know how to add header to ROM of type[%s]" % self.type)
 
     def expand(self, desired_size):
-        if self.type == 'Earthbound':
+        if self.type == ROM_TYPE_NAME_EARTHBOUND:
             if (desired_size != 0x400000) and (desired_size != 0x600000):
                 raise InvalidArgumentError("Cannot expand an %s ROM to size[%#x]" % (self.type, self.size))
             else:

--- a/coilsnake/model/common/blocks.py
+++ b/coilsnake/model/common/blocks.py
@@ -38,7 +38,11 @@ class Block(object):
         return self
 
     def __exit__(self, type, value, traceback):
-        del self.data
+        # There's no need to explicitly destroy self.data, as it will get
+        # destroyed when the Block goes out of scope.
+        # If using the Block as a context manager, this will usually happen at
+        # the end of the `with Block() as b` scope.
+        pass
 
     def reset(self, size=0):
         self.data = array.array('B', [0] * size)

--- a/coilsnake/model/eb/blocks.py
+++ b/coilsnake/model/eb/blocks.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 
 from coilsnake.exceptions.common.exceptions import CoilSnakeError
-from coilsnake.model.common.blocks import Block, Rom
+from coilsnake.model.common.blocks import Block, Rom, ROM_TYPE_NAME_EARTHBOUND
 from coilsnake.model.common.ips import IpsPatch
 from coilsnake.modules.eb.EbModule import comp, decomp
 from coilsnake.exceptions.eb.exceptions import InvalidEbCompressedDataError
@@ -73,7 +73,7 @@ class EbRom(Rom):
             pass  # Unknown variant
         else:
             patch = IpsPatch()
-            patch.load(os.path.join(ASSET_PATH, "rom-fixes", "Earthbound", patch_filename))
+            patch.load(os.path.join(ASSET_PATH, "rom-fixes", ROM_TYPE_NAME_EARTHBOUND, patch_filename))
             patch.apply(self)
             self._setup_rom_post_load()
             return

--- a/coilsnake/modules/common/PatchModule.py
+++ b/coilsnake/modules/common/PatchModule.py
@@ -2,6 +2,7 @@ import os
 
 from coilsnake.exceptions.common.exceptions import CoilSnakeError
 from coilsnake.model.common.ips import IpsPatch
+from coilsnake.model.common.blocks import ROM_TYPE_NAME_EARTHBOUND
 from coilsnake.modules.common.GenericModule import GenericModule
 from coilsnake.util.common.assets import ASSET_PATH
 from coilsnake.util.common.yml import yml_load, yml_dump
@@ -9,7 +10,7 @@ from coilsnake.util.common.yml import yml_load, yml_dump
 
 IPS_DIRECTORY = os.path.join(ASSET_PATH, "ips")
 REMOVED_PATCHES = {
-    "Earthbound": ["Battle Font Width Hack"]
+    ROM_TYPE_NAME_EARTHBOUND: ["Battle Font Width Hack"]
 }
 
 

--- a/coilsnake/modules/eb/EbModule.py
+++ b/coilsnake/modules/eb/EbModule.py
@@ -1,6 +1,7 @@
 import sys
 
 from coilsnake.modules.common.GenericModule import GenericModule
+from coilsnake.model.common.blocks import ROM_TYPE_NAME_EARTHBOUND
 
 try:
     from coilsnake.util.eb import native_comp
@@ -19,7 +20,7 @@ address_labels = dict()
 class EbModule(GenericModule):
     @staticmethod
     def is_compatible_with_romtype(romtype):
-        return romtype == "Earthbound"
+        return romtype == ROM_TYPE_NAME_EARTHBOUND
 
 
 # Comp/Decomp

--- a/coilsnake/modules/smb/SmbModule.py
+++ b/coilsnake/modules/smb/SmbModule.py
@@ -1,5 +1,5 @@
+from coilsnake.model.common.blocks import ROM_TYPE_NAME_SUPER_MARIO_BROS
 from coilsnake.modules.common.GenericModule import GenericModule
-
 
 def charToByte(c):
     if (c >= '0') and (c <= '9'):
@@ -66,4 +66,4 @@ def writeText(rom, addr, text, maxlen):
 class SmbModule(GenericModule):
     @staticmethod
     def is_compatible_with_romtype(romtype):
-        return romtype == "Super Mario Bros"
+        return romtype == ROM_TYPE_NAME_SUPER_MARIO_BROS

--- a/coilsnake/ui/common.py
+++ b/coilsnake/ui/common.py
@@ -14,7 +14,7 @@ from coilsnake.model.eb.blocks import EbRom
 from coilsnake.model.eb.ebp import EbpPatch
 from coilsnake.util.common.project import FORMAT_VERSION, PROJECT_FILENAME, get_version_name
 from coilsnake.exceptions.common.exceptions import CoilSnakeError, CCScriptCompilationError
-from coilsnake.model.common.blocks import Rom, ROM_TYPE_NAME_UNKNOWN
+from coilsnake.model.common.blocks import Rom, ROM_TYPE_NAME_UNKNOWN, ROM_TYPE_NAME_EARTHBOUND
 from coilsnake.ui.formatter import CoilSnakeFormatter
 from coilsnake.util.common.project import Project
 from coilsnake.util.common.assets import open_asset, ccscript_library_path
@@ -223,7 +223,7 @@ def decompile_script(rom_filename, project_path, progress_bar=None):
 
     rom = Rom()
     rom.from_file(rom_filename)
-    if rom.type != "Earthbound":
+    if rom.type != ROM_TYPE_NAME_EARTHBOUND:
         raise CoilSnakeError("Cannot decompile script of a non-Earthbound rom. A {} rom was supplied.".format(
             rom.type))
     del rom

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -19,7 +19,7 @@ import platform
 import os
 from PIL import ImageTk
 
-from coilsnake.model.common.blocks import Rom
+from coilsnake.model.common.blocks import Rom, ROM_TYPE_NAME_EARTHBOUND
 from coilsnake.ui import information, gui_util
 from coilsnake.ui.common import decompile_rom, compile_project, upgrade_project, setup_logging, decompile_script, \
     patch_rom, create_patch
@@ -274,7 +274,7 @@ Please configure Java in the Settings menu.""")
 
             base_rom_rom = Rom()
             base_rom_rom.from_file(base_rom)
-            if base_rom_rom.type == "Earthbound" and len(base_rom_rom) == 0x300000:
+            if base_rom_rom.type == ROM_TYPE_NAME_EARTHBOUND and len(base_rom_rom) == 0x300000:
                 confirm = tkinter.messagebox.askquestion("Expand Your Base ROM?",
                                                    "You are attempting to compile using a base ROM which is "
                                                    "unexpanded. It is likely that this will not succeed, as CoilSnake "


### PR DESCRIPTION
Instead of being hardcoded throughout the codebase, these are now defined in variables and those variables are used throughout.

This also has a fix for a bug introduced with the last PR, where ROM compilation will fail due to a block's data being deleted. The solution is to avoid deleting the block's data in the `__exit__` function, and just let it be destroyed when the Block does.