### PR TITLE
added preference for project in script decompilation

### DIFF
--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -701,6 +701,7 @@ Please configure Java in the Settings menu.""")
 
         def upgrade_tmp():
             self.preferences["default upgrade rom"] = rom_entry.get()
+            self.preferences["default upgrade project"] = project_entry.get()
             self.preferences.save()
             self.do_upgrade(rom_entry, project_entry)
 
@@ -711,6 +712,10 @@ Please configure Java in the Settings menu.""")
         if self.preferences["default upgrade rom"]:
             set_entry_text(entry=rom_entry,
                            text=self.preferences["default upgrade rom"])
+
+        if self.preferences["default upgrade project"]:
+            set_entry_text(entry=project_entry,
+                           text=self.preferences["default upgrade project"])
 
         return upgrade_frame
 

--- a/coilsnake/ui/gui.py
+++ b/coilsnake/ui/gui.py
@@ -724,6 +724,7 @@ Please configure Java in the Settings menu.""")
 
         def decompile_script_tmp():
             self.preferences["default decompile script rom"] = input_rom_entry.get()
+            self.preferences["default decompile script project"] = project_entry.get()
             self.preferences.save()
             self.do_decompile_script(input_rom_entry, project_entry)
 
@@ -734,6 +735,10 @@ Please configure Java in the Settings menu.""")
         if self.preferences["default decompile script rom"]:
             set_entry_text(entry=input_rom_entry,
                            text=self.preferences["default decompile script rom"])
+
+        if self.preferences["default decompile script project"]:
+            set_entry_text(entry=project_entry,
+                           text=self.preferences["default decompile script project"])
 
         return decompile_script_frame
 


### PR DESCRIPTION
Previously the script decompilation GUI page didn't save the project path, only the ROM path.  This is fairly annoying especially for testing the script decompilation while modifying the source code, so this simply adds that section in the preference file (which auto-saves just like the ROM path)