### PR TITLE
Expand NPC config table and sprite group table

### DIFF
--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -1,9 +1,10 @@
 import logging
+from functools import partial
 from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load
-from coilsnake.util.eb.pointer import write_asm_pointer, from_snes_address, to_snes_address
-
+from coilsnake.util.eb.pointer import write_asm_pointer, write_xl_pointer, from_snes_address, to_snes_address
+from coilsnake.util.eb.helper import is_in_bank
 
 class AsmPointer(object):
     def __init__(self, offset):
@@ -13,8 +14,16 @@ class AsmPointer(object):
         log.info("Writing pointer at " + hex(self.offset))
         write_asm_pointer(rom, self.offset, address)
 
+class XlPointer(object):
+    def __init__(self, offset):
+        self.offset = offset
+
+    def write(self, rom, address):
+        log.info("Writing xl pointer at " + hex(self.offset))
+        write_xl_pointer(rom, self.offset, address)
 
 log = logging.getLogger(__name__)
+
 
 
 class ExpandedTablesModule(EbModule):
@@ -22,8 +31,28 @@ class ExpandedTablesModule(EbModule):
     TABLE_OFFSETS = {
         0xD58D7A: [  # PSI NAMES
             AsmPointer(0x1c423)
-        ]
+        ],
+        0xCF8985: [  # NPC Configuration Table
+            AsmPointer(0x023E5), # in func C0222B/ Load NPCs
+            XlPointer(0x0C32E), # in func C0C30C
+            AsmPointer(0x131CA), # in func C13187/Talk to
+            AsmPointer(0x1327F), # in func C1323B/Check NPC
+            AsmPointer(0x1332F), # in func C1323B/Check NPC
+            XlPointer(0x1AD77), # in func C1AD42
+            AsmPointer(0x1B20B), # in func C1AF74/Use overworld item
+            AsmPointer(0x464C1), # in func C464B5/Create prepared NPC
+            AsmPointer(0x46831), # in func C4681A
+            AsmPointer(0x46930), # in func C46914
+        ],
     }
+
+    FREE_RANGES = [
+        # psi names
+        (from_snes_address(0xD58D7A), from_snes_address(0xD58F23 - 1)),
+        # npc config table
+        (from_snes_address(0xCF8985), from_snes_address(0xCFF2B5 - 1))
+    ]
+
 
     def __init__(self):
         super(ExpandedTablesModule, self).__init__()
@@ -39,7 +68,7 @@ class ExpandedTablesModule(EbModule):
         for offset, table in self.tables.items():
             new_table_offset = rom.allocate(size=table.size)
             table.to_block(rom, new_table_offset)
-            log.info("Writing table @ " + hex(new_table_offset))
+            log.info("Writing table @ " + hex(to_snes_address(new_table_offset)))
             for pointer in self.TABLE_OFFSETS[offset]:
                 pointer.write(rom, to_snes_address(new_table_offset))
 

--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -2,45 +2,28 @@ import logging
 from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load
-from coilsnake.util.eb.pointer import write_asm_pointer, write_xl_pointer, from_snes_address, to_snes_address
-
-class AsmPointer(object):
-    def __init__(self, offset):
-        self.offset = offset
-
-    def write(self, rom, address):
-        log.info("Writing pointer at " + hex(self.offset))
-        write_asm_pointer(rom, self.offset, address)
-
-class XlPointer(object):
-    def __init__(self, offset):
-        self.offset = offset
-
-    def write(self, rom, address):
-        log.info("Writing xl pointer at " + hex(self.offset))
-        write_xl_pointer(rom, self.offset, address)
+from coilsnake.util.eb.pointer import from_snes_address, to_snes_address, AsmPointerReference, XlPointerReference
 
 log = logging.getLogger(__name__)
-
 
 
 class ExpandedTablesModule(EbModule):
     NAME = "Expanded Tables"
     TABLE_OFFSETS = {
         0xD58D7A: [  # PSI NAMES
-            AsmPointer(0x1c423)
+            AsmPointerReference(0x1c423)
         ],
         0xCF8985: [  # NPC Configuration Table
-            AsmPointer(0x023E5), # in func C0222B/ Load NPCs
-            XlPointer(0x0C32E), # in func C0C30C
-            AsmPointer(0x131CA), # in func C13187/Talk to
-            AsmPointer(0x1327F), # in func C1323B/Check NPC
-            AsmPointer(0x1332F), # in func C1323B/Check NPC
-            XlPointer(0x1AD77), # in func C1AD42
-            AsmPointer(0x1B20B), # in func C1AF74/Use overworld item
-            AsmPointer(0x464C1), # in func C464B5/Create prepared NPC
-            AsmPointer(0x46831), # in func C4681A
-            AsmPointer(0x46930), # in func C46914
+            AsmPointerReference(0x023E5), # in func C0222B/ Load NPCs
+            XlPointerReference(0x0C32E), # in func C0C30C
+            AsmPointerReference(0x131CA), # in func C13187/Talk to
+            AsmPointerReference(0x1327F), # in func C1323B/Check NPC
+            AsmPointerReference(0x1332F), # in func C1323B/Check NPC
+            XlPointerReference(0x1AD77), # in func C1AD42
+            AsmPointerReference(0x1B20B), # in func C1AF74/Use overworld item
+            AsmPointerReference(0x464C1), # in func C464B5/Create prepared NPC
+            AsmPointerReference(0x46831), # in func C4681A
+            AsmPointerReference(0x46930), # in func C46914
         ],
     }
 

--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -1,10 +1,7 @@
-import logging
-from functools import partial
 from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load
 from coilsnake.util.eb.pointer import write_asm_pointer, write_xl_pointer, from_snes_address, to_snes_address
-from coilsnake.util.eb.helper import is_in_bank
 
 class AsmPointer(object):
     def __init__(self, offset):

--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -1,3 +1,4 @@
+import logging
 from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load

--- a/coilsnake/modules/eb/MiscTablesModule.py
+++ b/coilsnake/modules/eb/MiscTablesModule.py
@@ -14,7 +14,6 @@ class MiscTablesModule(EbModule):
         0xC3FD8D,  # Attract mode text
         0xD5F645,  # Timed Item Delivery
         0xE12F8A,  # Photographer
-        0xCF8985,  # NPC Configuration Table
         0xD5EA77,  # Condiment Table
         0xD5EBAB,  # Scripted Teleport Destination Table
         0xD5F2FB,  # Hotspots Table

--- a/coilsnake/modules/eb/SpriteGroupModule.py
+++ b/coilsnake/modules/eb/SpriteGroupModule.py
@@ -20,9 +20,7 @@ class SpriteGroupModule(EbModule):
                    (0x120000, 0x12ffff),
                    (0x130000, 0x13ffff),
                    (0x140000, 0x14ffff),
-                   (0x150000, 0x154fff)#,
-                   #(from_snes_address(0xEF133F), from_snes_address(0xEF1A7F - 1))
-                   ] # Sprite pointer table
+                   (0x150000, 0x154fff)]
     SPRITE_GROUP_TABLE_RELOCATIONS = [
         0x001DF9,
         0x001E79,

--- a/coilsnake/modules/eb/SpriteGroupModule.py
+++ b/coilsnake/modules/eb/SpriteGroupModule.py
@@ -6,7 +6,7 @@ from coilsnake.model.eb.table import eb_table_from_offset
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.image import open_indexed_image
 from coilsnake.util.common.yml import replace_field_in_yml, yml_load, yml_dump
-from coilsnake.util.eb.pointer import from_snes_address, to_snes_address, write_asm_pointer
+from coilsnake.util.eb.pointer import from_snes_address, to_snes_address, AsmPointerReference
 
 
 GROUP_POINTER_TABLE_OFFSET = 0xef133f
@@ -21,12 +21,12 @@ class SpriteGroupModule(EbModule):
                    (0x130000, 0x13ffff),
                    (0x140000, 0x14ffff),
                    (0x150000, 0x154fff)]
-    SPRITE_GROUP_TABLE_RELOCATIONS = [
-        0x001DF9,
-        0x001E79,
-        0x001FE0,
-        0x007A8B,
-        0x04B1D0,
+    SPRITE_GROUP_TABLE_REFERENCES = [
+        AsmPointerReference(0x001DF9),
+        AsmPointerReference(0x001E79),
+        AsmPointerReference(0x001FE0),
+        AsmPointerReference(0x007A8B),
+        AsmPointerReference(0x04B1D0),
     ]
 
     def __init__(self):
@@ -114,8 +114,8 @@ class SpriteGroupModule(EbModule):
 
         new_table_offset = rom.allocate(size=len(block))
         # Perform table relocation
-        for reloc in self.SPRITE_GROUP_TABLE_RELOCATIONS:
-            write_asm_pointer(block=rom, offset=reloc, pointer=to_snes_address(new_table_offset))
+        for pointer in self.SPRITE_GROUP_TABLE_REFERENCES:
+            pointer.write(rom, to_snes_address(new_table_offset))
         # Write new table data
         self.group_pointer_table.to_block(block=rom, offset=new_table_offset)
         self.palette_table.to_block(block=rom, offset=from_snes_address(PALETTE_TABLE_OFFSET))

--- a/coilsnake/util/eb/pointer.py
+++ b/coilsnake/util/eb/pointer.py
@@ -28,3 +28,8 @@ def write_asm_pointer(block, offset, pointer):
     block[offset + 2] = (pointer >> 8) & 0xff
     block[offset + 6] = (pointer >> 16) & 0xff
     block[offset + 7] = (pointer >> 24) & 0xff
+
+def write_xl_pointer(block, offset, pointer):
+    block[offset + 1] = pointer & 0xff
+    block[offset + 2] = (pointer >> 8) & 0xff
+    block[offset + 3] = (pointer >> 16) & 0xff

--- a/coilsnake/util/eb/pointer.py
+++ b/coilsnake/util/eb/pointer.py
@@ -1,4 +1,7 @@
+import logging
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError
+
+log = logging.getLogger(__name__)
 
 
 def from_snes_address(address):
@@ -33,3 +36,19 @@ def write_xl_pointer(block, offset, pointer):
     block[offset + 1] = pointer & 0xff
     block[offset + 2] = (pointer >> 8) & 0xff
     block[offset + 3] = (pointer >> 16) & 0xff
+
+class AsmPointerReference(object):
+    def __init__(self, offset):
+        self.offset = offset
+
+    def write(self, rom, address):
+        log.info("Writing pointer at " + hex(self.offset))
+        write_asm_pointer(rom, self.offset, address)
+
+class XlPointerReference(object):
+    def __init__(self, offset):
+        self.offset = offset
+
+    def write(self, rom, address):
+        log.info("Writing xl pointer at " + hex(self.offset))
+        write_xl_pointer(rom, self.offset, address)


### PR DESCRIPTION
As discussed in the discord. This lets NPC configs and sprite groups expand.

Please test and carefully review, I could easily have missed something up on integration.

Adding new NPCs/sprites crashes EbProjEditor. I'll be making another patch for that repo.