### PR TITLE
Fix brief naming music with naming skip enabled

### DIFF
--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -50,7 +50,6 @@ class SkipNamingModule(EbModule):
             offset = self.write_loader_asm(rom, offset, self.data["Food"],  6, 0x1f, 0x98)
             offset = self.write_loader_asm(rom, offset, self.data["Thing"], 6, 0x29, 0x98)
 
-
             if self.data["Enable Summary"]:
                 rom[offset:offset+6] = [0x28, 0x68, 0x5c, 0xc0, 0xfa, 0xc1]
             else:

--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -36,6 +36,7 @@ class SkipNamingModule(EbModule):
     def write_to_rom(self, rom):
         if self.data["Enable Skip"]:
             rom[0x1faae] = 0x5c
+            rom[0x1f8f1] = 0x10
             offset = rom.allocate(size=(10 + 4 * 5 * 5 + 3 * 6 * 5))
             rom.write_multi(0x1faaf, to_snes_address(offset), 3)
             rom[offset:offset+4] = [0x48, 0x08, 0xe2, 0x20]

--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -50,6 +50,7 @@ class SkipNamingModule(EbModule):
             offset = self.write_loader_asm(rom, offset, self.data["Food"],  6, 0x1f, 0x98)
             offset = self.write_loader_asm(rom, offset, self.data["Thing"], 6, 0x29, 0x98)
 
+
             if self.data["Enable Summary"]:
                 rom[offset:offset+6] = [0x28, 0x68, 0x5c, 0xc0, 0xfa, 0xc1]
             else:

--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -36,6 +36,9 @@ class SkipNamingModule(EbModule):
     def write_to_rom(self, rom):
         if self.data["Enable Skip"]:
             rom[0x1faae] = 0x5c
+            # this fixes the naming screen music playing briefly when skip naming is on
+            # it works by changing the jump from @CHANGE_TO_NAMING_SCREEN_MUSIC to @UNKNOWN18 (which normally runs directly after the music change)
+            # https://github.com/Herringway/ebsrc/blob/87f514cb4b77fa3193bcb122ea51f5de5cfdd9cf/src/intro/file_select_menu_loop.asm#L101
             rom[0x1f8f1] = 0x10
             offset = rom.allocate(size=(10 + 4 * 5 * 5 + 3 * 6 * 5))
             rom.write_multi(0x1faaf, to_snes_address(offset), 3)

--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -36,10 +36,12 @@ class SkipNamingModule(EbModule):
     def write_to_rom(self, rom):
         if self.data["Enable Skip"]:
             rom[0x1faae] = 0x5c
+
             # this fixes the naming screen music playing briefly when skip naming is on
             # it works by changing the jump from @CHANGE_TO_NAMING_SCREEN_MUSIC to @UNKNOWN18 (which normally runs directly after the music change)
             # https://github.com/Herringway/ebsrc/blob/87f514cb4b77fa3193bcb122ea51f5de5cfdd9cf/src/intro/file_select_menu_loop.asm#L101
             rom[0x1f8f1] = 0x10
+
             offset = rom.allocate(size=(10 + 4 * 5 * 5 + 3 * 6 * 5))
             rom.write_multi(0x1faaf, to_snes_address(offset), 3)
             rom[offset:offset+4] = [0x48, 0x08, 0xe2, 0x20]


### PR DESCRIPTION
This fixes a small but long-standing glitch when skipping the name selection: you can hear the naming screen music briefly before the game starts. It could previously be mitigated by adding "setup_music2(0)" to any CoilSnake file (changing the music to silence) but many hacks haven't added this (probably an oversight).

This PR won't affect backwards compatibility, but recompiling the same code with this new version will result in a different ROM.