### PR TITLE
Fix relocation overwrites

### DIFF
--- a/coilsnake/modules/eb/ExpandedTablesModule.py
+++ b/coilsnake/modules/eb/ExpandedTablesModule.py
@@ -51,7 +51,10 @@ class ExpandedTablesModule(EbModule):
             table.to_block(rom, new_table_offset)
             log.info("Writing table @ " + hex(to_snes_address(new_table_offset)))
             for pointer in self.TABLE_OFFSETS[offset]:
-                pointer.write(rom, to_snes_address(new_table_offset))
+                if pointer.validate_structure(rom):
+                    pointer.write(rom, to_snes_address(new_table_offset))
+                else:
+                    log.warn("Table relocation at %#x failed structure check - skipping...", pointer.offset)
 
     def read_from_project(self, resource_open):
         for table in self.tables.values():

--- a/coilsnake/modules/eb/SkipNamingModule.py
+++ b/coilsnake/modules/eb/SkipNamingModule.py
@@ -1,8 +1,11 @@
+import logging
 from coilsnake.modules.eb.EbModule import EbModule
 from coilsnake.util.common.yml import yml_load, yml_dump
 from coilsnake.util.eb.pointer import to_snes_address
 from coilsnake.util.eb.text import standard_text_to_byte_list
+from coilsnake.exceptions.common.exceptions import CoilSnakeUserError
 
+log = logging.getLogger(__name__)
 
 class SkipNamingModule(EbModule):
     NAME = "Skip Names"
@@ -35,14 +38,20 @@ class SkipNamingModule(EbModule):
 
     def write_to_rom(self, rom):
         if self.data["Enable Skip"]:
-            rom[0x1faae] = 0x5c
-
             # this fixes the naming screen music playing briefly when skip naming is on
             # it works by changing the jump from @CHANGE_TO_NAMING_SCREEN_MUSIC to @UNKNOWN18 (which normally runs directly after the music change)
             # https://github.com/Herringway/ebsrc/blob/87f514cb4b77fa3193bcb122ea51f5de5cfdd9cf/src/intro/file_select_menu_loop.asm#L101
-            rom[0x1f8f1] = 0x10
+            # Verify the code structure first:
+            if rom[0x1f8f0] == 0xD0 and rom[0x1f8f1] == 0x09:
+                rom[0x1f8f1] = 0x10
+            else:
+                log.warn("Unable to apply naming screen music bypass due to existing ASM changes")
 
             offset = rom.allocate(size=(10 + 4 * 5 * 5 + 3 * 6 * 5))
+            # Patch ASM to "JML newCode"
+            if bytes(rom.to_array()[0x1faae:0x1fab2]) != b'\xa9\x07\x00\x18':
+                raise CoilSnakeUserError("Naming ASM has already been patched - unable to apply naming skip")
+            rom[0x1faae] = 0x5c
             rom.write_multi(0x1faaf, to_snes_address(offset), 3)
             rom[offset:offset+4] = [0x48, 0x08, 0xe2, 0x20]
             offset += 4

--- a/coilsnake/util/eb/pointer.py
+++ b/coilsnake/util/eb/pointer.py
@@ -58,7 +58,8 @@ class AsmPointerReference(object):
             # Check if we're storing to sequential spots in the DP.
             # If we are, assume that the code hasn't been patched.
             dpLo, dpHi = m.groups()
-            return dpLo + 2 == dpHi
+            # Unfortunately, these are `bytes` objects with length 1, hence the [0]
+            return dpLo[0] + 2 == dpHi[0]
         # The structure of the reference is incorrect.
         # The code must have been changed somewhere else - don't patch.
         return False

--- a/coilsnake/util/eb/pointer.py
+++ b/coilsnake/util/eb/pointer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError
 
 log = logging.getLogger(__name__)
@@ -38,8 +39,29 @@ def write_xl_pointer(block, offset, pointer):
     block[offset + 3] = (pointer >> 16) & 0xff
 
 class AsmPointerReference(object):
+    POINTER_FORMAT = re.compile(
+        rb'''[\xa9\xa2\xa0]..  # Match LDA_i / LDX_i / LDY_i
+             [\x85\x86\x84](.) # Match STA_d / STX_d / STY_d
+             [\xa9\xa2\xa0]..  # Match LDA_i / LDX_i / LDY_i
+             [\x85\x86\x84](.) # Match STA_d / STX_d / STY_d
+        ''', re.VERBOSE)
+
     def __init__(self, offset):
         self.offset = offset
+
+    def validate_structure(self, rom):
+        region = bytes(rom.to_array()[self.offset:self.offset+10])
+        m = self.POINTER_FORMAT.match(region)
+        if m:
+            # The code has the correct overall structure.
+            # However, it's possible that it could be coincidence.
+            # Check if we're storing to sequential spots in the DP.
+            # If we are, assume that the code hasn't been patched.
+            dpLo, dpHi = m.groups()
+            return dpLo + 2 == dpHi
+        # The structure of the reference is incorrect.
+        # The code must have been changed somewhere else - don't patch.
+        return False
 
     def write(self, rom, address):
         log.info("Writing pointer at " + hex(self.offset))
@@ -48,6 +70,11 @@ class AsmPointerReference(object):
 class XlPointerReference(object):
     def __init__(self, offset):
         self.offset = offset
+
+    def validate_structure(self, rom):
+        opcode = rom[self.offset]
+        # The 65816 opcodes are pretty regular - check out this neat trick
+        return opcode & 0x0F == 0x0F
 
     def write(self, rom, address):
         log.info("Writing xl pointer at " + hex(self.offset))


### PR DESCRIPTION
Recently, we found an issue with the new NPC table relocation overwriting the user's custom CCS code. To avoid this, we will now check the actual code underlying a relocation, and skip writing the relocation if the code doesn't match.