### PR TITLE
Add GitHub actions, compiling CoilSnake for Windows on pushes and PRs

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -1,0 +1,26 @@
+name: Build CoilSnake with Win32 Py3.8
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+        cache: 'pip' # caching pip dependencies
+        architecture: 'x86'
+    - name: Build CoilSnake
+      run: python setup.py install
+    - name: Build .exe
+      run: python setup_exe.py
+    - name: Upload .exe
+      uses: actions/upload-artifact@v4
+      with:
+        name: CoilSnake
+        path: dist/CoilSnake.exe

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -1,9 +1,9 @@
 name: Build CoilSnake with Win32 Py3.8
 
 on:
-  push:
-  pull_request:
+  push: # by vote, we'll only build on pushes to master
     branches: [ master ]
+  pull_request: # build on pull request against any branch
 
 jobs:
   build:

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -15,6 +15,8 @@ jobs:
         python-version: '3.8'
         cache: 'pip' # caching pip dependencies
         architecture: 'x86'
+    - name: Install requirements
+      run: pip install -r requirements.txt
     - name: Build CoilSnake
       run: python setup.py install
     - name: Build .exe

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -17,8 +17,10 @@ jobs:
         architecture: 'x86'
     - name: Install requirements
       run: pip install -r requirements.txt
+    - name: Write build Git commit info
+      run: python set_git_commit.py --write
     - name: Build CoilSnake
-      run: $env:BUILD_GIT_COMMIT = git rev-parse --short "$env:GITHUB_SHA" ; python setup.py install
+      run: python setup.py install
     - name: Build .exe
       run: python setup_exe.py
     - name: Upload .exe

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -23,8 +23,10 @@ jobs:
       run: python setup.py install
     - name: Build .exe
       run: python setup_exe.py
+    - name: Rename .exe
+      run: python rename_exe_with_version.py
     - name: Upload .exe
       uses: actions/upload-artifact@v4
       with:
-        name: CoilSnake
-        path: dist/CoilSnake.exe
+        name: CoilSnake (Py3.8-win32)
+        path: dist/CoilSnake*.exe

--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install requirements
       run: pip install -r requirements.txt
     - name: Build CoilSnake
-      run: python setup.py install
+      run: $env:BUILD_GIT_COMMIT = git rev-parse --short "$env:GITHUB_SHA" ; python setup.py install
     - name: Build .exe
       run: python setup_exe.py
     - name: Upload .exe

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /coilsnake/assets/ccc/ccc
 /coilsnake/assets/ccc/lib/*.ccs
 .DS_store
+git_commit.py

--- a/coilsnake/ui/git_commit.py
+++ b/coilsnake/ui/git_commit.py
@@ -1,0 +1,1 @@
+GIT_COMMIT = None

--- a/coilsnake/ui/git_commit.py
+++ b/coilsnake/ui/git_commit.py
@@ -1,1 +1,0 @@
-GIT_COMMIT = None

--- a/coilsnake/ui/information.py
+++ b/coilsnake/ui/information.py
@@ -1,6 +1,9 @@
 from coilsnake.util.common import project
+from coilsnake.ui.git_commit import GIT_COMMIT
 
 VERSION = project.VERSION_NAMES[project.FORMAT_VERSION]
+if GIT_COMMIT:
+    VERSION = f"{VERSION}+git:{GIT_COMMIT}"
 RELEASE_DATE = "March 19, 2023"
 
 WEBSITE = "http://pk-hack.github.io/CoilSnake"
@@ -33,10 +36,10 @@ DEPENDENCIES = [
 
 
 def coilsnake_about():
-    description = """CoilSnake {version} - {website}
-Created by {author}
-Released on {release_date}
-""".format(version=VERSION, author=AUTHOR, release_date=RELEASE_DATE, website=WEBSITE)
+    description = f"""CoilSnake {VERSION} - {WEBSITE}
+Created by {AUTHOR}
+Released on {RELEASE_DATE}
+"""
 
     for dependency in DEPENDENCIES:
         description += "\n- " + dependency["name"]

--- a/coilsnake/ui/information.py
+++ b/coilsnake/ui/information.py
@@ -1,9 +1,13 @@
 from coilsnake.util.common import project
-from coilsnake.ui.git_commit import GIT_COMMIT
+# In case the file was not properly generated or bundled...
+try:
+    from coilsnake.ui.git_commit import GIT_COMMIT
+except:
+    GIT_COMMIT = None
 
 VERSION = project.VERSION_NAMES[project.FORMAT_VERSION]
 if GIT_COMMIT:
-    VERSION = f"{VERSION}+git:{GIT_COMMIT}"
+    VERSION = f"{VERSION}-next-{GIT_COMMIT}"
 RELEASE_DATE = "March 19, 2023"
 
 WEBSITE = "http://pk-hack.github.io/CoilSnake"

--- a/rename_exe_with_version.py
+++ b/rename_exe_with_version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import glob
+import os
+from coilsnake.ui.information import VERSION
+
+def rename_exe():
+    exe_paths = glob.glob('dist/CoilSnake*')
+    if not exe_paths:
+        print("Couldn't locate CoilSnake executable. Doing nothing...")
+        return
+    for exe_path in exe_paths:
+        new_exe_path = exe_path.replace('CoilSnake', f'CoilSnake-{VERSION}')
+        if exe_path != new_exe_path:
+            os.rename(exe_path, new_exe_path)
+
+if __name__ == '__main__':
+    rename_exe()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pip>=19.0
+pyinstaller>=6.3.0

--- a/set_git_commit.py
+++ b/set_git_commit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import sys
+
+GITHUB_SHA_ENV_VAR_NAME = 'GITHUB_SHA'
+COILSNAKE_GIT_COMMIT_PY_PATH = 'coilsnake/ui/git_commit.py'
+
+def get_git_commit():
+    # Try looking at the GitHub variable
+    revision = os.environ.get(GITHUB_SHA_ENV_VAR_NAME)
+    # If it wasn't set, run against head
+    if not revision:
+        revision = "HEAD"
+    # Try to run git rev-parse to get the short hash
+    try:
+        print('Getting short hash for Git revision:', revision)
+        git_commit = subprocess.check_output(['git', 'rev-parse', '--short', revision])
+        return git_commit.strip().decode()
+    except Exception as e:
+        print('Error when running rev-parse:', e, sep='\n')
+    # In case of error, return None
+    return None
+
+def write_git_commit(git_commit):
+    # Force git_commit to be a value, or None
+    git_commit = git_commit or None
+    git_commit_file_text = f'GIT_COMMIT = {git_commit!r}'
+    print(f"Writing '{COILSNAKE_GIT_COMMIT_PY_PATH}' with: {git_commit_file_text}")
+    with open(COILSNAKE_GIT_COMMIT_PY_PATH, 'w') as f:
+        print(git_commit_file_text, file=f)
+
+if __name__ == '__main__':
+    git_commit = get_git_commit()
+    print('Found Git commit short hash:', git_commit)
+    if '--write' in sys.argv[1:]:
+        write_git_commit(git_commit)

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,12 @@ from setuptools.extension import Extension
 
 git_commit = os.environ.get('BUILD_GIT_COMMIT')
 if git_commit:
-    with open('coilsnake/ui/git_commit.py', 'w') as f:
-        print(f'GIT_COMMIT = {git_commit!r}')
+    git_commit_file_text = f'GIT_COMMIT = {git_commit!r}'
+else:
+    git_commit_file_text = 'GIT_COMMIT = None'
+print("Writing coilsnake/ui/git_commit.py with:", git_commit_file_text)
+with open('coilsnake/ui/git_commit.py', 'w') as f:
+    print(git_commit_file_text, file=f)
 
 extra_compile_args = []
 

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,6 @@ import platform
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
-git_commit = os.environ.get('BUILD_GIT_COMMIT')
-if git_commit:
-    git_commit_file_text = f'GIT_COMMIT = {git_commit!r}'
-else:
-    git_commit_file_text = 'GIT_COMMIT = None'
-print("Writing coilsnake/ui/git_commit.py with:", git_commit_file_text)
-with open('coilsnake/ui/git_commit.py', 'w') as f:
-    print(git_commit_file_text, file=f)
-
 extra_compile_args = []
 
 if platform.system() != "Windows":

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 
+import os
+import platform
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
-import platform
+
+git_commit = os.environ.get('BUILD_GIT_COMMIT')
+if git_commit:
+    with open('coilsnake/ui/git_commit.py', 'w') as f:
+        print(f'GIT_COMMIT = {git_commit!r}')
 
 extra_compile_args = []
 


### PR DESCRIPTION
This PR adds GitHub action support. This will build a Windows executable whenever:
- changes are pushed into the `master` branch
- a pull request is created

This will hopefully make it easy to share development versions of CoilSnake.