### PR TITLE
Patch music engine to avoid echo buffer overwriting sample data

### DIFF
--- a/coilsnake/model/eb/musicpack.py
+++ b/coilsnake/model/eb/musicpack.py
@@ -910,13 +910,14 @@ class EngineMusicPack(SongMusicPack):
         engine_bytes = bytearray(engine_block.to_list())
         # Check if the data transfer routine has already been changed
         if engine_bytes[0x26b:0x26e] == b'\x3f\xe1\x0e':
+            log.info("Patching music engine to avoid sample corruption due to echo.")
             # Apply patch to disable echo before data transfer
             new_code_addr = len(engine_bytes) + cls.MAIN_PART_ADDR
             engine_bytes[0x26b:0x26e] = b'\x3f' + new_code_addr.to_bytes(2, 'little')
             engine_bytes += bytes.fromhex('eb 4d f0 13 6d e8 00 3f 2c 0b ae 1c 1c 1c bc fd e5 fd 00 f0 fb fe f9 5f e1 0e')
         # Rebuild the engine block and return it
         out_block = Block()
-        out_block.from_list(engine_bytes)
+        out_block.from_list([x for x in engine_bytes])
         return out_block
 
 def check_if_song_is_part_of_another(song_num: int, song_pack: SongMusicPack, song_addr: int) -> Union[None, SongThatIsPartOfAnother]:

--- a/coilsnake/model/eb/musicpack.py
+++ b/coilsnake/model/eb/musicpack.py
@@ -897,7 +897,7 @@ class EngineMusicPack(SongMusicPack):
             raise InvalidUserDataError("Data for engine pack ${:02X} is too long by {} bytes. "
                                        "Maybe your \"in-engine\" songs are too large.".format(self.pack_num, overage))
         # Have a helpful debug output for the user
-        log.info("Engine pack has %d bytes of free space available.", DYNAMIC_SONG_DATA_START - song_output_ptr)
+        log.debug("Engine pack has %d bytes of free space available.", DYNAMIC_SONG_DATA_START - song_output_ptr)
         output_parts += always_loaded_song_parts
 
         # Get dynamically loaded song data that is in this pack (Gas Station 1 in vanilla)


### PR DESCRIPTION
Recently, we've become aware of a bug. When transitioning from a song with a non-zero echo delay value to a new song which uses instrument samples that would overlap with the previous echo buffer, the samples may become corrupted independent of the echo value used by the new song. This is because the echo feature was not disabled when the instruments for the new song were uploaded.

This branch adds a new feature where CoilSnake will patch the music engine to disable echo when uploading data.

This is the assembly code added to the SPC, assembled by hand:
```
<          > ; push old echo value
< eb 4d    >     mov y, $4d
< f0 13    >     beq _exit
< 6d       >     push y
<          > ; call existing code at $0b2c with A=0 to disable echo
< e8 00    >     mov a, #0
< 3f 2c 0b >     call $0b2c
<          > ; wait for (old echo) * 16ms = 2ms * (old echo) * 8
< ae       >     pull a
< 1c       >     asl a
< 1c       >     asl a
< 1c       >     asl a
< bc       >     inc a
< fd       >     mov y, a
< e5 fd 00 > -   mov a, $00fd
< f0 fb    >     beq -
< fe f9    >     dbnz y, -
<          > ; continue with normal code
<          > _exit:
< 5f e1 0e >     jmp $0ee1
```