### PR TITLE
add support for CLI in executable binary

### DIFF
--- a/CoilSnake.spec
+++ b/CoilSnake.spec
@@ -87,10 +87,10 @@ exe = EXE(
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,
-    console=debug,
+    hide_console='hide-early',
     icon='coilsnake/assets/images/CoilSnake.ico',
     manifest=None,
-    windowed=True
+    console=True
 )
 
 if platform.system() != 'Darwin':

--- a/script/gui.py
+++ b/script/gui.py
@@ -4,6 +4,11 @@ import sys
 sys.path.append(".")
 
 from coilsnake.ui.gui import main
+from coilsnake.ui.cli import main as cli_main
 
 if __name__ == '__main__':
-    main()
+    # if we recieve arguments, run the cli instead
+    if len(sys.argv) > 1:
+        sys.exit(cli_main())
+    else:
+        main()


### PR DESCRIPTION
CoilSnake's command line interface is only usable via the source code. This commit adds the ability for the CLI to be accessed through an executable binary.

This changes CoilSnake.spec to no longer consider the program windowed, instead making it a console application with the extra option `hide_console='hide-early'` set. In script/gui.py, the entry file of the binary, a check is added which will switch to CLI mode (script/cli.py) if extra arguments are passed, and skip running the GUI entirely.

* Booting CoilSnake from File Explorer, the taskbar, etc. will have the same functionality - the GUI will open with no console window.
* Booting CoilSnake from Command Prompt **with no arguments** will boot the GUI, with it now being a blocking process.
* Booting CoilSnake from Command Prompt **with arguments** will use the CLI instead. 