### PR TITLE
CI: Fetch all commits and tags

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # setuptools-scm uses tags and commit counts to set the version
     - uses: actions/setup-python@v5
       with:
         python-version: '3.8'


### PR DESCRIPTION
This is required for now because of how setuptools_scm relies on tags and the number of commits since that tag (via `git describe`, I guess) to determine the version number string. (Without that info, the version will be named "0.1.dev1+g(hash)" every time, possibly even for actual releases.)

A more efficient solution may be possible in the future; see actions/checkout#249 and pypa/setuptools-scm#480

I've pushed the official `v4.2` tag to my forked repo to make sure that this works before merging it.