### PR TITLE
Update CCScriptWriter dependency URL in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.8"
 dependencies = [
     "Pillow>=3.0.0",
     "PyYAML>=3.11",
-    "CCScriptWriter @ https://github.com/pk-hack/CCScriptWriter/tarball/master",
+    "CCScriptWriter @ https://github.com/pk-hack/CCScriptWriter/archive/refs/heads/master.tar.gz",
     "ccscript @ https://github.com/charasyn/ccscript_legacy/archive/refs/tags/v1.500.tar.gz",
     # ??? CoilSnake hasn't been tested on Mac in a while. Is this still needed?
     "pyobjc-framework-Cocoa; platform_system == 'Darwin'",


### PR DESCRIPTION
Fixes #312 

This change to the pyproject file updates the path to CCScriptWriter to use the Github refs pattern, which supports specifying the file extension. This works around issues with installing dependencies where the filetype could not be inferred from the `master` bundle path that did not include a filetype extension, which depended on the HTTP client to infer the filetype based on MIME type and append an extension. 