### PR TITLE
Fix creation of IPS patches with records beginning at 454F46

### DIFF
--- a/coilsnake/model/common/ips.py
+++ b/coilsnake/model/common/ips.py
@@ -128,7 +128,8 @@ class IpsPatch(object):
                             records[i] = t
                         else:
                             i -= 1
-                            records[i] = hr.to_list()[i]
+                            index -= 1
+                            records[i] = hr.__getitem__(i).to_bytes(1, byteorder='big')
                 if index < cr.__len__() and index < hr.__len__():
                     s = cr.__getitem__(index).to_bytes(1, byteorder='big')
                     t = hr.__getitem__(index).to_bytes(1, byteorder='big')


### PR DESCRIPTION
When a ROM has a change that begins at address 454F46 (ASCII `EOF`), it can't normally be encoded in an IPS file, because that offset value is used to mark the end of the patch. CoilSnake did have code to catch that case, but it seems like it was never tested, at least not in any recent version of Python... it caused a single `int` to be inserted as the change to make to an offset, rather than a `bytes` object. All of the other code was based on `bytes` objects being appended together, so the next loop iteration would raise a TypeError (`unsupported operand type(s) for +=: 'int' and 'bytes'`)

Changes were tested by changing an all-zeroes file to have the bytes `DE AD` at offset 454F46 and confirming that the IPS patch contained a 3-byte change beginning at offset 454F45 consisting of `00 DE AD`.

The design of this patch creation loop is... kinda weird, with how it processes -1 or 0 or 1 bytes each loop iteration (this PR fixes the only -1 case), and how it manually calls methods like `__len__()` and `__getitem__(index)`. But it doesn't seem buggy apart from this one thing.