### PR TITLE
Correct flash and other status vulnerabilites

### DIFF
--- a/coilsnake/assets/structures/eb.yml
+++ b/coilsnake/assets/structures/eb.yml
@@ -1678,21 +1678,21 @@
   - name: Flash vulnerability
     size: 1
     values:
-    - 100%
-    - 70%
-    - 40%
-    - 5%
+    - 99%
+    - 50%
+    - 10%
+    - 0%
   - name: Paralysis vulnerability
     size: 1
     values:
-    - 100%
+    - 99%
     - 50%
     - 10%
     - 0%
   - name: Hypnosis/Brainshock vulnerability
     size: 1
     values:
-    - 100%
+    - 99%
     - 50%
     - 10%
     - 0%


### PR DESCRIPTION
Corrects vulnerability values for flash, paralysis, and hypnosis according to values reported at https://datacrystal.tcrf.net/wiki/EarthBound/Status_PSI_weakness_value.

Closes #249