### PR TITLE
CompressedGraphicsModule: fix bad FREE_RANGES end address

### DIFF
--- a/coilsnake/modules/eb/CompressedGraphicsModule.py
+++ b/coilsnake/modules/eb/CompressedGraphicsModule.py
@@ -89,7 +89,7 @@ class CompressedGraphicsModule(EbModule):
     NAME = "Compressed Graphics"
     FREE_RANGES = [(0x2021a8, 0x20ed02),  # Town Map data
                    (0x214ec1, 0x21ae7b),  # Company Logos, "Produced by" and "Presented by", and Gas Station
-                   (0x21ea50, 0x21f203)]  # Town map icon graphics and palette
+                   (0x21ea50, 0x21f202)]  # Town map icon graphics and palette
 
     def __init__(self):
         super(CompressedGraphicsModule, self).__init__()


### PR DESCRIPTION
FREE_RANGES are inclusive address ranges, and E1F203 is the address of the spritemap data for the hamburger shop map marker. In rare circumstances, this could cause the very first byte (Y position) of the first portion of the sprite to be overwritten with arbitrary data, if that block of free space was filled all the way to the end.

Probably fixes #316. Hopefully @ichee can confirm that the fix works on their end?