### PR TITLE
Verify free ranges and merge them together when possible

### DIFF
--- a/coilsnake/model/common/blocks.py
+++ b/coilsnake/model/common/blocks.py
@@ -1,4 +1,5 @@
 import array
+from bisect import bisect
 import copy
 import os
 from zlib import crc32
@@ -262,11 +263,34 @@ class AllocatableBlock(Block):
     def deallocate(self, range):
         check_range_validity(range, self.size)
 
-        # TODO do some check so that unallocated ranges don't overlap
-        # TODO attach contiguous unallocated ranges if possible
+        # Unallocated ranges should never overlap; otherwise we may write
+        # multiple pieces of data to the same addresses!
+        # Since we keep self.unallocated_ranges in sorted order, it's okay to
+        # use bisect (binary search) to find the place at which to insert it
+        insertion_point = bisect(self.unallocated_ranges, range)
+        previous_range = self.unallocated_ranges[insertion_point - 1] if insertion_point > 0 else None
+        next_range = self.unallocated_ranges[insertion_point] if insertion_point < len(self.unallocated_ranges) else None
+        # Checking these variables as booleans is safe here, because unallocated_ranges only contains tuples of length 2.
+        # Sequences (including tuples) are truthy if they aren't empty.
+        if previous_range and (range[0] <= previous_range[1]):
+            raise InvalidArgumentError(f"Range {range} overlaps with existing unallocated range {previous_range}!")
+        if next_range and (next_range[0] <= range[1]):
+            raise InvalidArgumentError(f"Range {range} overlaps with existing unallocated range {next_range}!")
 
-        self.unallocated_ranges.append(range)
-        self.unallocated_ranges.sort()
+        # Attach contiguous unallocated ranges if possible (not across banks)
+        # This is kinda SNES specific, and (Ex)HiROM specific... but this is an
+        # EarthBound hacking tool, so that should be fine
+        merge_with_previous = (range[0] & 0xFFFF) != 0 and previous_range and (previous_range[1] == range[0] - 1)
+        merge_with_next = (range[1] & 0xFFFF) != 0xFFFF and next_range and (range[1] + 1 == next_range[0])
+        if merge_with_previous and merge_with_next:
+            self.unallocated_ranges[insertion_point - 1] = (previous_range[0], next_range[1])
+            del self.unallocated_ranges[insertion_point]
+        elif merge_with_previous:
+            self.unallocated_ranges[insertion_point - 1] = (previous_range[0], range[1])
+        elif merge_with_next:
+            self.unallocated_ranges[insertion_point] = (range[0], next_range[1])
+        else:
+            self.unallocated_ranges.insert(insertion_point, range)
 
     def allocate(self, data=None, size=None, can_write_to=None):
         if data is None and size is None:


### PR DESCRIPTION
As of creating the PR, I haven't tested this yet.

One of the TODOs in the code for deallocating areas of the ROM was found to be useful to implement for [the Mother 2 prototype version of CoilSnake](https://github.com/Rickisthe1/CoilSnake-m2-basic/commit/07773917a7baa62601be6fb0201afd1a95ec6ebf), since it was easy to add ranges of free space that accidentally overlapped. This PR deals with that and also makes it possible to merge adjacent blocks of free space in the same bank, ensuring both greater correctness (when new tables/free ranges are added to CoilSnake) and greater potential for space efficiency (by making it possible for an insertion into the ROM to span multiple adjacent deallocated ranges).

I had some concerns about including code specific to EarthBound/HiROM SNES games in a `common` folder, but CoilSnake has been EB-specific for a while, and the logic should work for any future expansion chip accelerated hacks people may decide to make, too (there are some boards for the SA-1 and Super-FX/GSU chips that appear to work similar to HiROM in how they lay out memory, if I'm reading [Ares's SNES game board database](https://github.com/ares-emulator/ares/blob/54c898f199694c2d5866dad45aecb68fda4ee3b7/mia/Database/Super%20Famicom%20Boards.bml) correctly).