### PR TITLE
Ability to relocate song address table

### DIFF
--- a/coilsnake/model/eb/musicpack.py
+++ b/coilsnake/model/eb/musicpack.py
@@ -807,7 +807,7 @@ class SongMusicPack(GenericMusicPack):
 class EngineMusicPack(SongMusicPack):
     # This is used in modified engine.bins to have a different pointer to the song table.
     # asar assembler uses UTF-8 encoding.
-    # The footer can be located anywhere, but usually goes at the end of the file (as such we search backwards).
+    # The footer can be located anywhere, though, but the convention is at the end.
     # The format is this string followed by a pointer to the song table.
     FOOTER_IDENTIFIER_BYTES = bytes("COILSNAKE SONG TABLE POINTER", encoding="UTF-8")
     
@@ -959,8 +959,8 @@ class EngineMusicPack(SongMusicPack):
         except OutOfBoundsError:
             pass
         if len(song_table_pointer_pointers) > 1:
-            raise InvalidUserDataError("engine.bin contains more than one footer pointing to the location of the song table. Found at: {}".format(
-                ["$" + hex(i-len(footer_match))[2:].zfill(4) for i in song_table_pointer_pointers]
+            raise InvalidUserDataError("engine.bin contains more than one footer pointing to the location of the song table. Found footers at: {} (SPC addresses)".format(
+                ["$" + hex(i-len(footer_match) + 0x500)[2:].zfill(4).upper() for i in song_table_pointer_pointers]
             ))
         
         if len(song_table_pointer_pointers) == 0:

--- a/coilsnake/model/eb/musicpack.py
+++ b/coilsnake/model/eb/musicpack.py
@@ -949,7 +949,7 @@ class EngineMusicPack(SongMusicPack):
         return block[start_addr:start_addr + size]
 
     def get_song_address_table_pointer(self) -> int:
-        # search for CoilSnake footerw
+        # search for CoilSnake footer
         # (there's probably a better way to do this. I don't know how to best work with Block objects.)
         engine_bytes = bytes(self.engine_parts[EngineMusicPack.MAIN_PART_ADDR].to_list())
         footer_match = EngineMusicPack.FOOTER_IDENTIFIER_BYTES
@@ -959,9 +959,9 @@ class EngineMusicPack(SongMusicPack):
         except OutOfBoundsError:
             pass
         if len(song_table_pointer_pointers) > 1:
-            raise InvalidUserDataError("engine.bin contains more than one footer pointing to the location of the song table. Found at: {}").format(
-                "$" + hex(i-len(footer_match))[2:].zfill(4) for i in song_table_pointer_pointers
-            )
+            raise InvalidUserDataError("engine.bin contains more than one footer pointing to the location of the song table. Found at: {}".format(
+                ["$" + hex(i-len(footer_match))[2:].zfill(4) for i in song_table_pointer_pointers]
+            ))
         
         if len(song_table_pointer_pointers) == 0:
             log.info("Using default song table location.")


### PR DESCRIPTION
This PR adds the ability to change the location in the sound engine binary that the song address table is written to.

This makes it significantly easier to write new code for the sound engine (especially custom SFX) as a current limitation is that the song table has to remain in a constant location, and thus it becomes difficult to edit the code and data before it.

The implementation is based on a piece of data that CoilSnake can identify including a pointer to the location of the song table. Specifically, a UTF-8 string followed by the pointer. This may look like the following in a disassembly:
```asm
db "COILSNAKE SONG TABLE POINTER"
dw Song_Table
```

This string does not appear as binary data anywhere in the vanilla sound driver. If this data is not found, then the song table will be written to the default location. If more than one instance of this data is found, an error will be thrown.