### PR TITLE
Remove extension module build step in pyinstaller spec

### DIFF
--- a/CoilSnake.spec
+++ b/CoilSnake.spec
@@ -7,10 +7,6 @@ import shutil
 import sys
 import sysconfig
 
-from setuptools.sandbox import run_setup
-
-run_setup('setup.py', ['build_ext'])
-
 debug = False
 
 # This logic is specific to setuptools. It may change in future versions, as it did in 62.1.0.


### PR DESCRIPTION
Attempts to fix issues Vittorio ran into when building with a recent versions of setuptools (v80.0.0 and onward).