### PR TITLE
Print output from the CCScript compiler if there is any

### DIFF
--- a/coilsnake/ui/common.py
+++ b/coilsnake/ui/common.py
@@ -129,7 +129,9 @@ def compile_project(project_path, base_rom_filename, output_rom_filename, ccscri
                     "-o", output_rom_filename] + script_filenames
         ccc_returncode, ccc_log = ccc(ccc_args)
 
-        if ccc_returncode == 0:
+        if ccc_returncode == 0 and ccc_log:
+            log.info("CCScript compilation succeeded with output:\n" + ccc_log)
+        elif ccc_returncode == 0:
             log.info("Finished compiling CCScript")
         else:
             raise CCScriptCompilationError("CCScript compilation failed with output:\n" + ccc_log)


### PR DESCRIPTION
Currently, the CCScript compiler's output is only printed if an error occurs and compilation completely fails. This PR changes that to print the output in the success case, too. This solves the problem of the CCScript compiler issuing warnings for certain behaviors and the user being completely unable to see the warnings.

There are many people who want certain CCScript things to be an error, partly because of this issue (and partly because they *should* eventually be made errors). Invalid characters in control code byte sections, and extra ignored parts of expression blocks in springs, have caused a lot of people annoyance. Hopefully this change allows people to identify and fix those issues before we make anything a hard error.