### PR TITLE
Add explicit error handling for battle sprites of unexpected sizes

### DIFF
--- a/coilsnake/model/eb/sprites.py
+++ b/coilsnake/model/eb/sprites.py
@@ -2,6 +2,7 @@ from array import array
 
 from PIL import Image
 
+from coilsnake.exceptions.common.exceptions import IndexOutOfRangeError, InvalidUserDataError
 from coilsnake.model.common.table import EnumeratedLittleEndianIntegerTableEntry, RowTableEntry, \
     LittleEndianIntegerTableEntry
 from coilsnake.util.common.helper import grouped
@@ -22,6 +23,8 @@ class EbBattleSprite(object):
         return (self.width // 32) * (self.height // 32) * 4 * 4 * 32
 
     def from_block(self, block, offset=0, size=0):
+        if size < 0 or size >= len(BATTLE_SPRITE_SIZES):
+            raise IndexOutOfRangeError("Invalid battle sprite size {}".format(size))
         width, height = BATTLE_SPRITE_SIZES[size]
         if (self.width != width) or (self.height != height):
             self.width = width
@@ -66,6 +69,9 @@ class EbBattleSprite(object):
 
     def from_image(self, image):
         if (self.width, self.height) != image.size:
+            (width, height) = image.size
+            if (width, height) not in BATTLE_SPRITE_SIZES:
+                raise InvalidUserDataError("Invalid sprite size {}x{}".format(width, height))
             self.width, self.height = image.size
             self.sprite = [array('B', [0] * self.width) for y in range(self.height)]
 

--- a/coilsnake/modules/eb/EnemyModule.py
+++ b/coilsnake/modules/eb/EnemyModule.py
@@ -1,5 +1,6 @@
 import logging
 
+from coilsnake.exceptions.common.exceptions import IndexOutOfRangeError, InvalidUserDataError, CoilSnakeTraceableError
 from coilsnake.model.eb.blocks import EbCompressibleBlock
 from coilsnake.model.eb.enemy_groups import EnemyGroupTableEntry
 from coilsnake.model.eb.palettes import EbPalette
@@ -60,7 +61,10 @@ class EnemyModule(EbModule):
                     block=rom,
                     offset=from_snes_address(self.graphics_pointer_table[i][0]))
                 sprite = EbBattleSprite()
-                sprite.from_block(block=compressed_block, offset=0, size=self.graphics_pointer_table[i][1])
+                try:
+                    sprite.from_block(block=compressed_block, offset=0, size=self.graphics_pointer_table[i][1])
+                except IndexOutOfRangeError as e:
+                    raise CoilSnakeTraceableError("Error while reading battle sprite {} from ROM".format(i), e.args[0]) from e
                 self.battle_sprites.append(sprite)
 
         # Determine how many palettes there are
@@ -195,6 +199,9 @@ class EnemyModule(EbModule):
                 self.enemy_config_table[i][4] = 0
                 self.enemy_config_table[i][14] = 0
                 continue
+            except InvalidUserDataError as e:
+                # Something was wrong with the battle sprite image
+                raise CoilSnakeTraceableError("Error while reading battle sprite {0:03} from project".format(i), e.args[0]) from e
 
             sprite_hash = battle_sprite.hash()
             try:


### PR DESCRIPTION
An exception with an actual CoilSnake-specific error message mentioning the problematic sprite is now raised.

Fixes #343 (in a way that feels better than the minimal solution mentioned in the issue)