### PR TITLE
Downgrade CI to windows-2022 image

### DIFF
--- a/.github/workflows/pyinstaller.yaml
+++ b/.github/workflows/pyinstaller.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Until the ccscript package is fixed to build on VS2026 / C++17, this will get CoilSnake CI working again. This is apparently the only remaining Windows image that still has Visual Studio 2022, as Coop discovered.

VS2022 is also the last Visual Studio version that supports Windows 7 and 8, so the downgrade is probably a good idea to support those anyway. (Even if anyone still using Windows 7 is using workarounds like VxKex to run unsupported software anyway)