### PR TITLE
Port test suite back to unittest, and fix the easy bitrot

### DIFF
--- a/tests/coilsnake_test.py
+++ b/tests/coilsnake_test.py
@@ -3,41 +3,42 @@ import tempfile
 
 import os
 from PIL import Image, ImageChops
-from nose.tools import assert_is_none
-from nose.tools.trivial import eq_
+from unittest import TestCase
 
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "test_data")
 TEST_IMAGE_DIR = os.path.join(TEST_DATA_DIR, "images")
 
 
-def assert_files_equal(expected, result):
-    for i in zip_longest(iter(expected), iter(result)):
-        eq_(i[0], i[1])
+def earthbound_rom_available():
+    return os.path.exists(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
 
 
-def assert_images_equal(expected, result):
-    assert_is_none(ImageChops.difference(expected, result).getbbox())
-
-
-class BaseTestCase(object):
+class BaseTestCase(TestCase):
     def test_baseline(self):
         pass
 
+    def assert_files_equal(self, expected, result):
+        for i in zip_longest(iter(expected), iter(result)):
+            self.assertEqual(i[0], i[1])
 
-class TemporaryWritableFileTestCase(object):
-    def setup(self):
+
+    def assert_images_equal(self, expected, result):
+        self.assertIsNone(ImageChops.difference(expected, result).getbbox())
+
+class TemporaryWritableFileTestCase(TestCase):
+    def setUp(self):
         self.temporary_wo_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
         self.temporary_wo_file_name = self.temporary_wo_file.name
 
-    def teardown(self):
+    def tearDown(self):
         if not self.temporary_wo_file.closed:
             self.temporary_wo_file.close()
         os.remove(self.temporary_wo_file_name)
 
 
-class TilesetImageTestCase(object):
-    def setup(self):
+class TilesetImageTestCase(TestCase):
+    def setUp(self):
         self.tile_image_01_fp = open(os.path.join(TEST_IMAGE_DIR, "tile_image_01.png"), 'rb')
         self.tile_image_01_img = Image.open(self.tile_image_01_fp)
         self.tile_8x8_2bpp_fp = open(os.path.join(TEST_IMAGE_DIR, "tile_8x8_2bpp.png"), 'rb')
@@ -49,7 +50,7 @@ class TilesetImageTestCase(object):
         self.tile_8x16_4bpp_fp = open(os.path.join(TEST_IMAGE_DIR, "tile_8x16_4bpp.png"), 'rb')
         self.tile_8x16_4bpp_img = Image.open(self.tile_8x16_4bpp_fp)
 
-    def teardown(self):
+    def tearDown(self):
         self.tile_image_01_fp.close()
         del self.tile_image_01_img
         self.tile_8x8_2bpp_fp.close()
@@ -62,25 +63,25 @@ class TilesetImageTestCase(object):
         del self.tile_8x16_4bpp_img
 
 
-class SpriteGroupTestCase(object):
-    def setup(self):
+class SpriteGroupTestCase(TestCase):
+    def setUp(self):
         self.spritegroup_1_f = open(os.path.join(TEST_IMAGE_DIR, "spritegroup_16x24_1.png"), 'rb')
         self.spritegroup_1_img = Image.open(self.spritegroup_1_f)
         self.spritegroup_2_f = open(os.path.join(TEST_IMAGE_DIR, "spritegroup_16x24_2.png"), 'rb')
         self.spritegroup_2_img = Image.open(self.spritegroup_2_f)
 
-    def teardown(self):
+    def tearDown(self):
         self.spritegroup_1_f.close()
         del self.spritegroup_1_img
         self.spritegroup_2_f.close()
         del self.spritegroup_2_img
 
 
-class SwirlTestCase(object):
-    def setup(self):
+class SwirlTestCase(TestCase):
+    def setUp(self):
         self.swirl_1_f = open(os.path.join(TEST_IMAGE_DIR, "swirl_1.png"), 'rb')
         self.swirl_1_img = Image.open(self.swirl_1_f)
 
-    def teardown(self):
+    def tearDown(self):
         self.swirl_1_f.close()
         del self.swirl_1_img

--- a/tests/model/common/test_blocks.py
+++ b/tests/model/common/test_blocks.py
@@ -1,356 +1,359 @@
 import os
 
-from nose.tools import assert_equal, assert_not_equal, assert_raises, assert_list_equal, assert_false, assert_true, \
-    assert_is_instance
-from nose.tools.nontrivial import raises
+from unittest import skipUnless
 
 from coilsnake.model.common.blocks import Block, AllocatableBlock, Rom, ROM_TYPE_NAME_UNKNOWN
-from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR
+from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR, earthbound_rom_available
 from coilsnake.exceptions.common.exceptions import FileAccessError, OutOfBoundsError, InvalidArgumentError, \
     CouldNotAllocateError, NotEnoughUnallocatedSpaceError
 
 
 class TestBlock(BaseTestCase):
-    def setup(self):
+    def setUp(self):
         self.block = Block()
 
-    def teardown(self):
+    def tearDown(self):
         del self.block
 
     def test_baseline(self):
         pass
 
     def test_empty(self):
-        assert_equal(len(self.block), 0)
-        assert_equal(len(self.block.data), 0)
+        self.assertEqual(len(self.block), 0)
+        self.assertEqual(len(self.block.data), 0)
 
     def test_from_file(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_null.bin"))
-        assert_equal(len(self.block), 1024)
-        assert_list_equal(self.block.to_list(), [0] * 1024)
+        self.assertEqual(len(self.block), 1024)
+        self.assertListEqual(self.block.to_list(), [0] * 1024)
 
     def test_from_file_unhappy(self):
         # Attempt to load a directory
-        assert_raises(FileAccessError, self.block.from_file, TEST_DATA_DIR)
+        self.assertRaises(FileAccessError, self.block.from_file, TEST_DATA_DIR)
         # Attempt to load a nonexistent file
-        assert_raises(FileAccessError, self.block.from_file, os.path.join(TEST_DATA_DIR, "doesnotexist.bin"))
+        self.assertRaises(FileAccessError, self.block.from_file, os.path.join(TEST_DATA_DIR, "doesnotexist.bin"))
         # Attempt to load a file in a nonexistent directory
-        assert_raises(FileAccessError, self.block.from_file, os.path.join(TEST_DATA_DIR, "dne", "dne.bin"))
+        self.assertRaises(FileAccessError, self.block.from_file, os.path.join(TEST_DATA_DIR, "dne", "dne.bin"))
 
     def test_from_list(self):
         self.block.from_list([0, 1, 2, 3, 4, 5])
-        assert_equal(len(self.block), 6)
-        assert_list_equal(self.block.to_list(), [0, 1, 2, 3, 4, 5])
+        self.assertEqual(len(self.block), 6)
+        self.assertListEqual(self.block.to_list(), [0, 1, 2, 3, 4, 5])
 
         self.block.from_list([])
-        assert_equal(len(self.block), 0)
-        assert_list_equal(self.block.to_list(), [])
+        self.assertEqual(len(self.block), 0)
+        self.assertListEqual(self.block.to_list(), [])
 
         self.block.from_list([69])
-        assert_equal(len(self.block), 1)
-        assert_list_equal(self.block.to_list(), [69])
+        self.assertEqual(len(self.block), 1)
+        self.assertListEqual(self.block.to_list(), [69])
 
     def test_getitem(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_rand.bin"))
 
-        assert_equal(self.block[0], 0x25)
-        assert_equal(self.block[1023], 0x20)
-        assert_equal(self.block[0x3e3], 0xf4)
-        assert_equal(self.block[1023], self.block[-1])
+        self.assertEqual(self.block[0], 0x25)
+        self.assertEqual(self.block[1023], 0x20)
+        self.assertEqual(self.block[0x3e3], 0xf4)
+        self.assertEqual(self.block[1023], self.block[-1])
 
-        assert_raises(OutOfBoundsError, self.block.__getitem__, 1024)
-        assert_raises(OutOfBoundsError, self.block.__getitem__, 9999)
+        self.assertRaises(OutOfBoundsError, self.block.__getitem__, 1024)
+        self.assertRaises(OutOfBoundsError, self.block.__getitem__, 9999)
 
     def test_getitem_slice(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_rand.bin"))
 
-        assert_is_instance(self.block[0:1], Block)
+        self.assertIsInstance(self.block[0:1], Block)
 
-        assert_list_equal(self.block[0:0].to_list(), [])
-        assert_list_equal(self.block[0x25c:0x25c].to_list(), [])
-        assert_list_equal(self.block[0x25c:0x25d].to_list(), [0xa0])
-        assert_list_equal(self.block[0x25c:0x25c + 5].to_list(), [0xa0, 0x0b, 0x71, 0x5d, 0x91])
-        assert_list_equal(self.block[0x25c:0x25c + 5].to_list(), [0xa0, 0x0b, 0x71, 0x5d, 0x91])
-        assert_list_equal(self.block[1022:1024].to_list(), [0x10, 0x20])
+        self.assertListEqual(self.block[0:0].to_list(), [])
+        self.assertListEqual(self.block[0x25c:0x25c].to_list(), [])
+        self.assertListEqual(self.block[0x25c:0x25d].to_list(), [0xa0])
+        self.assertListEqual(self.block[0x25c:0x25c + 5].to_list(), [0xa0, 0x0b, 0x71, 0x5d, 0x91])
+        self.assertListEqual(self.block[0x25c:0x25c + 5].to_list(), [0xa0, 0x0b, 0x71, 0x5d, 0x91])
+        self.assertListEqual(self.block[1022:1024].to_list(), [0x10, 0x20])
 
-        assert_raises(InvalidArgumentError, self.block.__getitem__, slice(0, -1))
-        assert_raises(OutOfBoundsError, self.block.__getitem__, slice(-2, -1))
-        assert_raises(InvalidArgumentError, self.block.__getitem__, slice(1024, 0))
-        assert_raises(InvalidArgumentError, self.block.__getitem__, slice(1024, -1))
-        assert_raises(InvalidArgumentError, self.block.__getitem__, slice(1022, 3))
+        self.assertRaises(InvalidArgumentError, self.block.__getitem__, slice(0, -1))
+        self.assertRaises(OutOfBoundsError, self.block.__getitem__, slice(-2, -1))
+        self.assertRaises(InvalidArgumentError, self.block.__getitem__, slice(1024, 0))
+        self.assertRaises(InvalidArgumentError, self.block.__getitem__, slice(1024, -1))
+        self.assertRaises(InvalidArgumentError, self.block.__getitem__, slice(1022, 3))
 
     def test_setitem(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_rand.bin"))
 
         self.block[1] = 0xaa
-        assert_equal(self.block[0], 0x25)
-        assert_equal(self.block[1], 0xaa)
-        assert_equal(self.block[2], 0x38)
-        assert_raises(OutOfBoundsError, self.block.__setitem__, 1024, 0xbb)
+        self.assertEqual(self.block[0], 0x25)
+        self.assertEqual(self.block[1], 0xaa)
+        self.assertEqual(self.block[2], 0x38)
+        self.assertRaises(OutOfBoundsError, self.block.__setitem__, 1024, 0xbb)
 
-        assert_raises(InvalidArgumentError, self.block.__setitem__, 5, 0x1234)
-        assert_raises(InvalidArgumentError, self.block.__setitem__, 0, 0x100)
-        assert_raises(InvalidArgumentError, self.block.__setitem__, 1, -1)
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, 5, 0x1234)
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, 0, 0x100)
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, 1, -1)
 
     def test_setitem_slice(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_rand.bin"))
 
-        assert_list_equal(self.block[0:3].to_list(), [0x25, 0x20, 0x38])
+        self.assertListEqual(self.block[0:3].to_list(), [0x25, 0x20, 0x38])
         self.block[0:3] = [0xeb, 0x15, 0x66]
-        assert_list_equal(self.block[0:3].to_list(), [0xeb, 0x15, 0x66])
+        self.assertListEqual(self.block[0:3].to_list(), [0xeb, 0x15, 0x66])
         self.block[0:1024] = [5] * 1024
-        assert_equal(self.block[0:1024].to_list(), [5] * 1024)
+        self.assertEqual(self.block[0:1024].to_list(), [5] * 1024)
 
-        assert_raises(InvalidArgumentError, self.block.__setitem__, slice(5, 0), [])
-        assert_raises(InvalidArgumentError, self.block.__setitem__, slice(55, 55), [])
-        assert_raises(OutOfBoundsError, self.block.__setitem__, slice(-1, 2), [])
-        assert_raises(OutOfBoundsError, self.block.__setitem__, slice(1, 1025), [0] * 1024)
-        assert_raises(OutOfBoundsError, self.block.__setitem__, slice(1024, 1025), [1])
-        assert_raises(InvalidArgumentError, self.block.__setitem__, slice(0, 1), [])
-        assert_raises(InvalidArgumentError, self.block.__setitem__, slice(0, 1), [1, 2, 3])
-        assert_raises(InvalidArgumentError, self.block.__setitem__, slice(0, 5), [1, 2])
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, slice(5, 0), [])
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, slice(55, 55), [])
+        self.assertRaises(OutOfBoundsError, self.block.__setitem__, slice(-1, 2), [])
+        self.assertRaises(OutOfBoundsError, self.block.__setitem__, slice(1, 1025), [0] * 1024)
+        self.assertRaises(OutOfBoundsError, self.block.__setitem__, slice(1024, 1025), [1])
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, slice(0, 1), [])
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, slice(0, 1), [1, 2, 3])
+        self.assertRaises(InvalidArgumentError, self.block.__setitem__, slice(0, 5), [1, 2])
 
     def test_read_multi(self):
         self.block.from_list([0x03, 0xa1, 0x44, 0x15, 0x92, 0x65])
 
-        assert_equal(self.block.read_multi(0, 4), 0x1544a103)
-        assert_equal(self.block.read_multi(1, 4), 0x921544a1)
-        assert_equal(self.block.read_multi(1, 1), 0xa1)
-        assert_equal(self.block.read_multi(1, 2), 0x44a1)
-        assert_equal(self.block.read_multi(2, 3), 0x921544)
-        assert_equal(self.block.read_multi(3, 3), 0x659215)
-        assert_equal(self.block.read_multi(5, 1), 0x65)
-        assert_equal(self.block.read_multi(0, 0), 0)
-        assert_equal(self.block.read_multi(5, 0), 0)
+        self.assertEqual(self.block.read_multi(0, 4), 0x1544a103)
+        self.assertEqual(self.block.read_multi(1, 4), 0x921544a1)
+        self.assertEqual(self.block.read_multi(1, 1), 0xa1)
+        self.assertEqual(self.block.read_multi(1, 2), 0x44a1)
+        self.assertEqual(self.block.read_multi(2, 3), 0x921544)
+        self.assertEqual(self.block.read_multi(3, 3), 0x659215)
+        self.assertEqual(self.block.read_multi(5, 1), 0x65)
+        self.assertEqual(self.block.read_multi(0, 0), 0)
+        self.assertEqual(self.block.read_multi(5, 0), 0)
 
-        assert_raises(InvalidArgumentError, self.block.read_multi, 0, -1)
-        assert_raises(InvalidArgumentError, self.block.read_multi, 0, -99)
-        assert_raises(OutOfBoundsError, self.block.read_multi, -1, 3)
-        assert_raises(OutOfBoundsError, self.block.read_multi, 7, 1)
-        assert_raises(OutOfBoundsError, self.block.read_multi, 5, 2)
-        assert_raises(OutOfBoundsError, self.block.read_multi, 0, 7)
+        self.assertRaises(InvalidArgumentError, self.block.read_multi, 0, -1)
+        self.assertRaises(InvalidArgumentError, self.block.read_multi, 0, -99)
+        self.assertRaises(OutOfBoundsError, self.block.read_multi, -1, 3)
+        self.assertRaises(OutOfBoundsError, self.block.read_multi, 7, 1)
+        self.assertRaises(OutOfBoundsError, self.block.read_multi, 5, 2)
+        self.assertRaises(OutOfBoundsError, self.block.read_multi, 0, 7)
 
     def test_write_multi(self):
         self.block.from_list([0x03, 0xa1, 0x44, 0x15, 0x92, 0x65])
 
         self.block.write_multi(0, 0, 0)
-        assert_list_equal(self.block.to_list(), [0x03, 0xa1, 0x44, 0x15, 0x92, 0x65])
+        self.assertListEqual(self.block.to_list(), [0x03, 0xa1, 0x44, 0x15, 0x92, 0x65])
         self.block.write_multi(0, 0xff, 1)
-        assert_list_equal(self.block.to_list(), [0xff, 0xa1, 0x44, 0x15, 0x92, 0x65])
+        self.assertListEqual(self.block.to_list(), [0xff, 0xa1, 0x44, 0x15, 0x92, 0x65])
         self.block.write_multi(1, 0xa1b2, 2)
-        assert_list_equal(self.block.to_list(), [0xff, 0xb2, 0xa1, 0x15, 0x92, 0x65])
+        self.assertListEqual(self.block.to_list(), [0xff, 0xb2, 0xa1, 0x15, 0x92, 0x65])
         self.block.write_multi(2, 0x100000f, 4)
-        assert_list_equal(self.block.to_list(), [0xff, 0xb2, 0x0f, 0x00, 0x00, 0x01])
+        self.assertListEqual(self.block.to_list(), [0xff, 0xb2, 0x0f, 0x00, 0x00, 0x01])
 
-        assert_raises(InvalidArgumentError, self.block.write_multi, 0, 0, -1)
-        assert_raises(OutOfBoundsError, self.block.write_multi, -1, 0, 1)
-        assert_raises(OutOfBoundsError, self.block.write_multi, -1, 0, 1)
-        assert_raises(OutOfBoundsError, self.block.write_multi, 0, 0, 7)
-        assert_raises(OutOfBoundsError, self.block.write_multi, 1, 0, 6)
-        assert_raises(OutOfBoundsError, self.block.write_multi, 3, 0, 4)
+        self.assertRaises(InvalidArgumentError, self.block.write_multi, 0, 0, -1)
+        self.assertRaises(OutOfBoundsError, self.block.write_multi, -1, 0, 1)
+        self.assertRaises(OutOfBoundsError, self.block.write_multi, -1, 0, 1)
+        self.assertRaises(OutOfBoundsError, self.block.write_multi, 0, 0, 7)
+        self.assertRaises(OutOfBoundsError, self.block.write_multi, 1, 0, 6)
+        self.assertRaises(OutOfBoundsError, self.block.write_multi, 3, 0, 4)
 
     def test_len(self):
         self.block.from_list([0x03, 0xa1, 0x44, 0x15, 0x92, 0x65])
-        assert_equal(len(self.block), 6)
+        self.assertEqual(len(self.block), 6)
         self.block.from_list([])
-        assert_equal(len(self.block), 0)
+        self.assertEqual(len(self.block), 0)
 
 
 class TestAllocatableBlock(TestBlock):
-    def setup(self):
+    def setUp(self):
         self.block = AllocatableBlock()
 
     def test_getitem_slice_type(self):
         self.block.from_list([0] * 10)
-        assert_is_instance(self.block[0:1], Block)
+        self.assertIsInstance(self.block[0:1], Block)
 
     def test_deallocate(self):
         self.block.from_list([0] * 10)
-        assert_raises(InvalidArgumentError, self.block.deallocate, (1, 0))
-        assert_raises(InvalidArgumentError, self.block.deallocate, (8, 2))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (-1, 0))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (-1, 9))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (-1, 10))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (0, 10))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (1, 11))
-        assert_raises(OutOfBoundsError, self.block.deallocate, (9, 10))
+        self.assertRaises(InvalidArgumentError, self.block.deallocate, (1, 0))
+        self.assertRaises(InvalidArgumentError, self.block.deallocate, (8, 2))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (-1, 0))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (-1, 9))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (-1, 10))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (0, 10))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (1, 11))
+        self.assertRaises(OutOfBoundsError, self.block.deallocate, (9, 10))
 
         self.block.deallocate((0, 2))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 2)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 2)])
         self.block.deallocate((4, 9))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 2), (4, 9)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 2), (4, 9)])
 
     def test_mark_allocated(self):
         self.block.from_list([0] * 10)
-        assert_raises(InvalidArgumentError, self.block.mark_allocated, (1, 0))
-        assert_raises(InvalidArgumentError, self.block.mark_allocated, (8, 2))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (-1, 0))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (-1, 9))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (-1, 10))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (0, 10))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (1, 11))
-        assert_raises(OutOfBoundsError, self.block.mark_allocated, (9, 10))
-        assert_raises(CouldNotAllocateError, self.block.mark_allocated, (0, 1))
+        self.assertRaises(InvalidArgumentError, self.block.mark_allocated, (1, 0))
+        self.assertRaises(InvalidArgumentError, self.block.mark_allocated, (8, 2))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (-1, 0))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (-1, 9))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (-1, 10))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (0, 10))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (1, 11))
+        self.assertRaises(OutOfBoundsError, self.block.mark_allocated, (9, 10))
+        self.assertRaises(CouldNotAllocateError, self.block.mark_allocated, (0, 1))
 
         self.block.from_list([0] * 100)
         self.block.deallocate((0, 99))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 99)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 99)])
         # Mark middle as allocated, splitting the range into two
         self.block.mark_allocated((3, 44))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 2), (45, 99)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 2), (45, 99)])
         # Again, but splitting a range into the smallest possible size
         self.block.mark_allocated((1, 1))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 0), (2, 2), (45, 99)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 0), (2, 2), (45, 99)])
         # Destroying a range of size 1
         self.block.mark_allocated((0, 0))
-        assert_list_equal(self.block.unallocated_ranges, [(2, 2), (45, 99)])
+        self.assertListEqual(self.block.unallocated_ranges, [(2, 2), (45, 99)])
         # Allocate from the beginning
         self.block.mark_allocated((45, 55))
-        assert_list_equal(self.block.unallocated_ranges, [(2, 2), (56, 99)])
+        self.assertListEqual(self.block.unallocated_ranges, [(2, 2), (56, 99)])
         # Allocate from the end
         self.block.mark_allocated((80, 99))
-        assert_list_equal(self.block.unallocated_ranges, [(2, 2), (56, 79)])
+        self.assertListEqual(self.block.unallocated_ranges, [(2, 2), (56, 79)])
         # Allocate an entire range
         self.block.mark_allocated((56, 79))
-        assert_list_equal(self.block.unallocated_ranges, [(2, 2)])
+        self.assertListEqual(self.block.unallocated_ranges, [(2, 2)])
 
         self.block.from_list([0] * 0x50)
         self.block.unallocated_ranges = [(0, 0xf), (0x10, 0x1f), (0x20, 0x2f), (0x30, 0x3f)]
         # Mark a range free that spans multiple unallocated ranges
         self.block.mark_allocated((0x5, 0x25))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 0x4), (0x26, 0x2f), (0x30, 0x3f)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 0x4), (0x26, 0x2f), (0x30, 0x3f)])
         self.block.mark_allocated((0x26, 0x31))
-        assert_list_equal(self.block.unallocated_ranges, [(0, 0x4), (0x32, 0x3f)])
+        self.assertListEqual(self.block.unallocated_ranges, [(0, 0x4), (0x32, 0x3f)])
         # Test invalid allocation
-        assert_raises(CouldNotAllocateError, self.block.mark_allocated, (0x31, 0x32))
-        assert_raises(CouldNotAllocateError, self.block.mark_allocated, (0x3f, 0x40))
-        assert_raises(CouldNotAllocateError, self.block.mark_allocated, (0x31, 0x40))
+        self.assertRaises(CouldNotAllocateError, self.block.mark_allocated, (0x31, 0x32))
+        self.assertRaises(CouldNotAllocateError, self.block.mark_allocated, (0x3f, 0x40))
+        self.assertRaises(CouldNotAllocateError, self.block.mark_allocated, (0x31, 0x40))
 
     def test_get_unallocated_portions_of_range(self):
         self.block.from_list([0] * 50)
         self.block.deallocate((0, 10))
-        assert_list_equal(self.block.get_unallocated_portions_of_range((2, 8)), [(2, 8)])
-        assert_list_equal(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10)])
+        self.assertListEqual(self.block.get_unallocated_portions_of_range((2, 8)), [(2, 8)])
+        self.assertListEqual(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10)])
         self.block.deallocate((12, 14))
-        assert_list_equal(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10), (12, 14)])
+        self.assertListEqual(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10), (12, 14)])
         self.block.deallocate((18, 30))
-        assert_list_equal(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10), (12, 14), (18, 20)])
-        assert_list_equal(self.block.get_unallocated_portions_of_range((16, 32)), [(18, 30)])
+        self.assertListEqual(self.block.get_unallocated_portions_of_range((5, 20)), [(5, 10), (12, 14), (18, 20)])
+        self.assertListEqual(self.block.get_unallocated_portions_of_range((16, 32)), [(18, 30)])
 
     def test_is_unallocated(self):
         self.block.from_list([0] * 10)
-        assert_raises(InvalidArgumentError, self.block.is_unallocated, (1, 0))
-        assert_raises(InvalidArgumentError, self.block.is_unallocated, (8, 2))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (-1, 0))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (-1, 9))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (-1, 10))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (0, 10))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (1, 11))
-        assert_raises(OutOfBoundsError, self.block.is_unallocated, (9, 10))
+        self.assertRaises(InvalidArgumentError, self.block.is_unallocated, (1, 0))
+        self.assertRaises(InvalidArgumentError, self.block.is_unallocated, (8, 2))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (-1, 0))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (-1, 9))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (-1, 10))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (0, 10))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (1, 11))
+        self.assertRaises(OutOfBoundsError, self.block.is_unallocated, (9, 10))
 
-        assert_false(self.block.is_unallocated((0, 0)))
-        assert_true(self.block.is_allocated((0, 0)))
+        self.assertFalse(self.block.is_unallocated((0, 0)))
+        self.assertTrue(self.block.is_allocated((0, 0)))
 
         self.block.deallocate((1, 3))
         self.block.deallocate((4, 5))
         self.block.deallocate((9, 9))
 
-        assert_true(self.block.is_unallocated((1, 3)))
-        assert_true(self.block.is_unallocated((4, 5)))
-        assert_true(self.block.is_unallocated((9, 9)))
-        assert_true(self.block.is_unallocated((1, 1)))
-        assert_false(self.block.is_unallocated((0, 1)))
-        assert_false(self.block.is_unallocated((1, 4)))
-        assert_false(self.block.is_unallocated((0, 4)))
-        assert_false(self.block.is_unallocated((0, 9)))
-        assert_false(self.block.is_unallocated((1, 9)))
+        self.assertTrue(self.block.is_unallocated((1, 3)))
+        self.assertTrue(self.block.is_unallocated((4, 5)))
+        self.assertTrue(self.block.is_unallocated((9, 9)))
+        self.assertTrue(self.block.is_unallocated((1, 1)))
+        self.assertFalse(self.block.is_unallocated((0, 1)))
+        self.assertFalse(self.block.is_unallocated((1, 4)))
+        self.assertFalse(self.block.is_unallocated((0, 4)))
+        self.assertFalse(self.block.is_unallocated((0, 9)))
+        self.assertFalse(self.block.is_unallocated((1, 9)))
 
     def test_allocate(self):
         self.block.from_list([0] * 100)
-        assert_raises(InvalidArgumentError, self.block.allocate)
-        assert_raises(InvalidArgumentError, self.block.allocate, None, 0)
-        assert_raises(InvalidArgumentError, self.block.allocate, None, -1)
-        assert_raises(InvalidArgumentError, self.block.allocate, None, -10)
-        assert_raises(InvalidArgumentError, self.block.allocate, [], None)
-        assert_raises(InvalidArgumentError, self.block.allocate, [1], 2)
+        self.assertRaises(InvalidArgumentError, self.block.allocate)
+        self.assertRaises(InvalidArgumentError, self.block.allocate, None, 0)
+        self.assertRaises(InvalidArgumentError, self.block.allocate, None, -1)
+        self.assertRaises(InvalidArgumentError, self.block.allocate, None, -10)
+        self.assertRaises(InvalidArgumentError, self.block.allocate, [], None)
+        self.assertRaises(InvalidArgumentError, self.block.allocate, [1], 2)
 
         # Allocate an entire range
         self.block.deallocate((0, 49))
-        assert_raises(NotEnoughUnallocatedSpaceError, self.block.allocate, None, 51)
+        self.assertRaises(NotEnoughUnallocatedSpaceError, self.block.allocate, None, 51)
         offset = self.block.allocate(size=50)
-        assert_equal(offset, 0)
-        assert_equal(self.block.unallocated_ranges, [])
+        self.assertEqual(offset, 0)
+        self.assertEqual(self.block.unallocated_ranges, [])
 
         # Allocate the beginning of a range
         self.block.deallocate((10, 39))
         offset = self.block.allocate(data=[0x12, 0x34, 0xef])
-        assert_equal(offset, 10)
-        assert_equal(self.block.unallocated_ranges, [(13, 39)])
-        assert_equal(self.block[offset:offset + 3].to_list(), [0x12, 0x34, 0xef])
-        assert_not_equal(self.block.to_list(), [0] * 100)
+        self.assertEqual(offset, 10)
+        self.assertEqual(self.block.unallocated_ranges, [(13, 39)])
+        self.assertEqual(self.block[offset:offset + 3].to_list(), [0x12, 0x34, 0xef])
+        self.assertNotEqual(self.block.to_list(), [0] * 100)
         self.block[offset:offset + 3] = [0] * 3
-        assert_equal(self.block.to_list(), [0] * 100)
+        self.assertEqual(self.block.to_list(), [0] * 100)
 
     def test_allocate_across_ranges(self):
         self.block.from_list([0] * 100)
         self.block.deallocate((0, 5))
         self.block.deallocate((6, 9))
-        assert_raises(NotEnoughUnallocatedSpaceError, self.block.allocate, None, 10)
+        self.assertRaises(NotEnoughUnallocatedSpaceError, self.block.allocate, None, 10)
 
 
 class TestRom(TestAllocatableBlock):
-    def setup(self):
+    def setUp(self):
         self.block = Rom()
 
     def test_detect_rom_type(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "EB_fake_noheader.smc"))
-        assert_equal(self.block.type, "Earthbound")
+        self.assertEqual(self.block.type, "Earthbound")
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "EB_fake_header.smc"))
-        assert_equal(self.block.type, "Earthbound")
+        self.assertEqual(self.block.type, "Earthbound")
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "empty.bin"))
-        assert_equal(self.block.type, ROM_TYPE_NAME_UNKNOWN)
+        self.assertEqual(self.block.type, ROM_TYPE_NAME_UNKNOWN)
         self.block.from_file(os.path.join(TEST_DATA_DIR, "binaries", "1kb_null.bin"))
-        assert_equal(self.block.type, ROM_TYPE_NAME_UNKNOWN)
+        self.assertEqual(self.block.type, ROM_TYPE_NAME_UNKNOWN)
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "EB_fake_header.smc"))
-        assert_equal(self.block.type, "Earthbound")
-        self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
-        assert_equal(self.block.type, "Earthbound")
+        self.assertEqual(self.block.type, "Earthbound")
 
-    @raises(NotImplementedError)
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
+    def test_detect_rom_type_earthbound(self):
+        self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
+        self.assertEqual(self.block.type, "Earthbound")
+
     def test_add_header_unknown(self):
         self.block.from_list([0])
-        self.block.add_header()
+        with self.assertRaises(NotImplementedError):
+            self.block.add_header()
 
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
     def test_add_header_eb(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
-        assert_equal(self.block.size, 0x300000)
+        self.assertEqual(self.block.size, 0x300000)
         self.block.add_header()
-        assert_equal(self.block.size, 0x300200)
-        assert_equal(len(self.block.data), 0x300200)
-        assert_equal(self.block[0:0x200].to_list(), [0] * 0x200)
+        self.assertEqual(self.block.size, 0x300200)
+        self.assertEqual(len(self.block.data), 0x300200)
+        self.assertEqual(self.block[0:0x200].to_list(), [0] * 0x200)
 
-    @raises(NotImplementedError)
     def test_expand_unknown(self):
         self.block.from_list([0])
-        self.block.expand(0x123456)
+        with self.assertRaises(NotImplementedError):
+            self.block.expand(0x123456)
 
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
     def test_expand_eb(self):
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
-        assert_raises(InvalidArgumentError, self.block.expand, 0x400200)
-        assert_raises(InvalidArgumentError, self.block.expand, 0x300000)
+        self.assertRaises(InvalidArgumentError, self.block.expand, 0x400200)
+        self.assertRaises(InvalidArgumentError, self.block.expand, 0x300000)
         self.block.expand(0x400000)
-        assert_equal(self.block.size, 0x400000)
-        assert_equal(len(self.block.data), 0x400000)
-        assert_list_equal(self.block[0x300000:0x400000].to_list(), [0] * 0x100000)
+        self.assertEqual(self.block.size, 0x400000)
+        self.assertEqual(len(self.block.data), 0x400000)
+        self.assertListEqual(self.block[0x300000:0x400000].to_list(), [0] * 0x100000)
         self.block.expand(0x600000)
-        assert_equal(self.block.size, 0x600000)
-        assert_equal(len(self.block.data), 0x600000)
-        assert_equal(self.block[0xffd5], 0x25)
-        assert_equal(self.block[0xffd7], 0x0d)
+        self.assertEqual(self.block.size, 0x600000)
+        self.assertEqual(len(self.block.data), 0x600000)
+        self.assertEqual(self.block[0xffd5], 0x25)
+        self.assertEqual(self.block[0xffd7], 0x0d)
 
         self.block.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
         self.block.expand(0x600000)
-        assert_equal(self.block.size, 0x600000)
-        assert_equal(len(self.block.data), 0x600000)
-        assert_equal(self.block[0xffd5], 0x25)
-        assert_equal(self.block[0xffd7], 0x0d)
+        self.assertEqual(self.block.size, 0x600000)
+        self.assertEqual(len(self.block.data), 0x600000)
+        self.assertEqual(self.block[0xffd5], 0x25)
+        self.assertEqual(self.block[0xffd7], 0x0d)

--- a/tests/model/common/test_table.py
+++ b/tests/model/common/test_table.py
@@ -1,6 +1,3 @@
-from nose.tools import assert_dict_equal, assert_list_equal, assert_raises, assert_equal, assert_is_instance
-from nose.tools.nontrivial import raises
-
 from coilsnake.exceptions.common.exceptions import TableError, \
     TableEntryInvalidYmlRepresentationError, TableEntryMissingDataError, TableSchemaError
 from coilsnake.model.common.blocks import Block
@@ -10,6 +7,10 @@ from tests.coilsnake_test import BaseTestCase
 
 
 class GenericTestTable(BaseTestCase):
+    def setUp(self):
+        if type(self) is GenericTestTable:
+            self.skipTest("Base class tests called directly")
+
     def test_from_block(self):
         table = Table(num_rows=len(self.TABLE_VALUES),
                       schema=self.TABLE_SCHEMA)
@@ -17,7 +18,7 @@ class GenericTestTable(BaseTestCase):
         block.from_list(self.BLOCK_DATA)
         table.from_block(block, 0)
 
-        assert_list_equal(table.values, self.TABLE_VALUES)
+        self.assertListEqual(table.values, self.TABLE_VALUES)
 
     def test_to_block(self):
         block = Block()
@@ -27,34 +28,34 @@ class GenericTestTable(BaseTestCase):
         table.values = self.TABLE_VALUES
         table.to_block(block, 0)
 
-        assert_list_equal(block.to_list(), self.BLOCK_DATA)
+        self.assertListEqual(block.to_list(), self.BLOCK_DATA)
 
     def test_from_yml_rep(self):
         table = Table(num_rows=len(self.TABLE_VALUES),
                       schema=self.TABLE_SCHEMA)
         table.from_yml_rep(self.YML_REP)
 
-        assert_list_equal(table.values, self.TABLE_VALUES)
+        self.assertListEqual(table.values, self.TABLE_VALUES)
 
     def test_to_yml_rep(self):
         table = Table(num_rows=len(self.TABLE_VALUES),
                       schema=self.TABLE_SCHEMA)
         table.values = self.TABLE_VALUES
-        assert_dict_equal(table.to_yml_rep(), self.YML_REP)
+        self.assertDictEqual(table.to_yml_rep(), self.YML_REP)
 
     def test_from_yml_rep_errors(self):
         table = Table(num_rows=1,
                       schema=self.TABLE_SCHEMA)
         for row, column_name, expected_error, expected_error_cause, yml_rep in self.BAD_YML_REPS:
-            print(row, column_name, expected_error)
-            with assert_raises(TableError) as cm:
+            # print(row, column_name, expected_error)
+            with self.assertRaises(TableError) as cm:
                 table.from_yml_rep(yml_rep)
             e = cm.exception
-            assert_equal(e.entry, 0)
-            assert_equal(e.field, column_name)
-            assert_is_instance(e.cause, expected_error)
+            self.assertEqual(e.entry, 0)
+            self.assertEqual(e.field, column_name)
+            self.assertIsInstance(e.cause, expected_error)
             if expected_error_cause:
-                assert_is_instance(e.cause.cause, expected_error_cause)
+                self.assertIsInstance(e.cause.cause, expected_error_cause)
 
 
 class TestGenericLittleEndianTable(GenericTestTable):
@@ -211,16 +212,16 @@ class TestBitfieldTableEntry(BaseTestCase):
     entry_class = BitfieldTableEntry.create(name="test", enumeration_class=enumeration_class, size=1)
 
     def test_from_yml_rep_legacy(self):
-        assert_equal(self.entry_class.from_yml_rep(0), set())
-        assert_equal(self.entry_class.from_yml_rep(1), set([0]))
-        assert_equal(self.entry_class.from_yml_rep(2), set([1]))
-        assert_equal(self.entry_class.from_yml_rep(3), set([0, 1]))
-        assert_equal(self.entry_class.from_yml_rep(255), set([0, 1, 2, 3, 4, 5, 6, 7]))
+        self.assertEqual(self.entry_class.from_yml_rep(0), set())
+        self.assertEqual(self.entry_class.from_yml_rep(1), set([0]))
+        self.assertEqual(self.entry_class.from_yml_rep(2), set([1]))
+        self.assertEqual(self.entry_class.from_yml_rep(3), set([0, 1]))
+        self.assertEqual(self.entry_class.from_yml_rep(255), set([0, 1, 2, 3, 4, 5, 6, 7]))
 
-    @raises(TableEntryInvalidYmlRepresentationError)
     def test_from_yml_rep_legacy_too_small(self):
-        self.entry_class.from_yml_rep(-1)
+        with self.assertRaises(TableEntryInvalidYmlRepresentationError):
+            self.entry_class.from_yml_rep(-1)
 
-    @raises(TableEntryInvalidYmlRepresentationError)
     def test_from_yml_rep_legacy_too_large(self):
-        self.entry_class.from_yml_rep(256)
+        with self.assertRaises(TableEntryInvalidYmlRepresentationError):
+            self.entry_class.from_yml_rep(256)

--- a/tests/model/eb/test_doors.py
+++ b/tests/model/eb/test_doors.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equal, assert_list_equal, assert_dict_equal, assert_not_equal
-
 from coilsnake.model.common.blocks import AllocatableBlock
 from coilsnake.model.eb.doors import Door, DoorType, NpcDoor, DestinationDirection, EscalatorOrStairwayDoor, \
     StairDirection, RopeOrLadderDoor, ClimbableType, SwitchDoor
@@ -14,12 +12,14 @@ class GenericTestDoor(BaseTestCase):
     DOOR_OFFSET = 0x10
     NEW_DOOR_OFFSET = 0x123
 
-    def setup(self):
+    def setUp(self):
+        if self.DOOR_TYPE is None:
+            self.skipTest("No door type specified")
         self.block = AllocatableBlock()
         self.block.from_list([0] * 0x100000)
         self.block[self.DOOR_OFFSET:self.DOOR_OFFSET + 5] = self.DOOR_DATA
 
-    def teardown(self):
+    def tearDown(self):
         del self.block
 
     def test_baseline(self):
@@ -28,20 +28,20 @@ class GenericTestDoor(BaseTestCase):
     def test_from_block(self):
         new_door = self.DOOR_CLASS()
         new_door.from_block(self.block, self.DOOR_OFFSET)
-        assert_equal(new_door, self.door)
+        self.assertEqual(new_door, self.door)
 
     def test_to_block(self):
         self.door.write_to_block(self.block, self.NEW_DOOR_OFFSET, {})
-        assert_list_equal(self.block[self.DOOR_OFFSET:self.DOOR_OFFSET + 3].to_list(),
+        self.assertListEqual(self.block[self.DOOR_OFFSET:self.DOOR_OFFSET + 3].to_list(),
                           [self.door.y, self.door.x, self.DOOR_TYPE])
 
     def test_yml_rep(self):
-        assert_dict_equal(self.door.yml_rep(), self.YML_REP)
+        self.assertDictEqual(self.door.yml_rep(), self.YML_REP)
 
     def test_from_yml_rep(self):
         new_door = self.DOOR_CLASS()
         new_door.from_yml_rep(self.YML_REP)
-        assert_equal(new_door, self.door)
+        self.assertEqual(new_door, self.door)
 
 
 class TestEscalatorDoor(GenericTestDoor):
@@ -54,8 +54,8 @@ class TestEscalatorDoor(GenericTestDoor):
                "X": 251,
                "Y": 123}
 
-    def setup(self):
-        super(TestEscalatorDoor, self).setup()
+    def setUp(self):
+        super(TestEscalatorDoor, self).setUp()
         self.door = EscalatorOrStairwayDoor(x=251, y=123, type=self.DOOR_TYPE, direction=StairDirection.SE)
 
 
@@ -69,8 +69,8 @@ class TestStairwayDoor(GenericTestDoor):
                "X": 251,
                "Y": 123}
 
-    def setup(self):
-        super(TestStairwayDoor, self).setup()
+    def setUp(self):
+        super(TestStairwayDoor, self).setUp()
         self.door = EscalatorOrStairwayDoor(x=251, y=123, type=self.DOOR_TYPE, direction=StairDirection.NE)
 
 
@@ -83,8 +83,8 @@ class TestRopeDoor(GenericTestDoor):
                "X": 251,
                "Y": 123}
 
-    def setup(self):
-        super(TestRopeDoor, self).setup()
+    def setUp(self):
+        super(TestRopeDoor, self).setUp()
         self.door = RopeOrLadderDoor(x=251, y=123, climbable_type=ClimbableType.ROPE)
 
 
@@ -97,8 +97,8 @@ class TestLadderDoor(GenericTestDoor):
                "X": 42,
                "Y": 169}
 
-    def setup(self):
-        super(TestLadderDoor, self).setup()
+    def setUp(self):
+        super(TestLadderDoor, self).setUp()
         self.door = RopeOrLadderDoor(x=42, y=169, climbable_type=ClimbableType.LADDER)
 
 
@@ -106,7 +106,9 @@ class GenericTestDestinationDoor(GenericTestDoor):
     DESTINATION_OFFSET = 0xF0AB0
     NEW_DESTINATION_OFFSET = 0x0F1BC0
 
-    def setup(self):
+    def setUp(self):
+        if self.DOOR_TYPE is None:
+            self.skipTest("No door type specified")
         self.block = AllocatableBlock()
         self.block.from_list([0] * 0x100000)
         self.block.deallocate((self.NEW_DESTINATION_OFFSET, 0x0F58EE))
@@ -116,8 +118,8 @@ class GenericTestDestinationDoor(GenericTestDoor):
 
     def test_to_block(self):
         super(GenericTestDestinationDoor, self).test_to_block()
-        assert_equal(self.block.read_multi(self.NEW_DOOR_OFFSET + 3, 2), self.NEW_DESTINATION_OFFSET & 0xffff)
-        assert_list_equal(self.block[self.NEW_DESTINATION_OFFSET:(
+        self.assertEqual(self.block.read_multi(self.NEW_DOOR_OFFSET + 3, 2), self.NEW_DESTINATION_OFFSET & 0xffff)
+        self.assertListEqual(self.block[self.NEW_DESTINATION_OFFSET:(
             self.NEW_DESTINATION_OFFSET + len(self.DESTINATION_DATA))].to_list(),
                           self.DESTINATION_DATA)
 
@@ -125,9 +127,9 @@ class GenericTestDestinationDoor(GenericTestDoor):
         tmp_address_labels = dict()
         self.door.write_to_block(self.block, self.NEW_DOOR_OFFSET, tmp_address_labels)
         self.door.write_to_block(self.block, self.NEW_DOOR_OFFSET + 5, tmp_address_labels)
-        assert_list_equal(self.block[self.NEW_DOOR_OFFSET:self.NEW_DOOR_OFFSET + 5].to_list(),
+        self.assertListEqual(self.block[self.NEW_DOOR_OFFSET:self.NEW_DOOR_OFFSET + 5].to_list(),
                           self.block[self.NEW_DOOR_OFFSET + 5:self.NEW_DOOR_OFFSET + 10].to_list())
-        assert_equal(len(tmp_address_labels), 1)
+        self.assertEqual(len(tmp_address_labels), 1)
 
     def test_to_block_do_not_reuse_destination(self):
         tmp_address_labels = dict()
@@ -135,11 +137,11 @@ class GenericTestDestinationDoor(GenericTestDoor):
         # This works because every door with a destination has a text_pointer
         self.door.text_pointer.address += 1
         self.door.write_to_block(self.block, self.NEW_DOOR_OFFSET + 5, tmp_address_labels)
-        assert_list_equal(self.block[self.NEW_DOOR_OFFSET:self.NEW_DOOR_OFFSET + 3].to_list(),
+        self.assertListEqual(self.block[self.NEW_DOOR_OFFSET:self.NEW_DOOR_OFFSET + 3].to_list(),
                           self.block[self.NEW_DOOR_OFFSET + 5:self.NEW_DOOR_OFFSET + 8].to_list())
-        assert_not_equal(self.block[self.NEW_DOOR_OFFSET + 3:self.NEW_DOOR_OFFSET + 5].to_list(),
+        self.assertNotEqual(self.block[self.NEW_DOOR_OFFSET + 3:self.NEW_DOOR_OFFSET + 5].to_list(),
                          self.block[self.NEW_DOOR_OFFSET + 8:self.NEW_DOOR_OFFSET + 10].to_list())
-        assert_equal(len(tmp_address_labels), 2)
+        self.assertEqual(len(tmp_address_labels), 2)
 
 
 class TestSwitchDoor(GenericTestDestinationDoor):
@@ -156,8 +158,8 @@ class TestSwitchDoor(GenericTestDestinationDoor):
         "Event Flag": 0x8098
     }
 
-    def setup(self):
-        super(TestSwitchDoor, self).setup()
+    def setUp(self):
+        super(TestSwitchDoor, self).setUp()
         self.door = SwitchDoor(x=251, y=123, flag=0x8098, text_address=0x00f13245)
 
 
@@ -174,8 +176,8 @@ class TestPersonDoor(GenericTestDestinationDoor):
         "Text Pointer": "$ea92a5",
     }
 
-    def setup(self):
-        super(TestPersonDoor, self).setup()
+    def setUp(self):
+        super(TestPersonDoor, self).setUp()
         self.door = NpcDoor(x=251, y=123, type=self.DOOR_TYPE, text_address=0x00ea92a5)
 
 
@@ -192,8 +194,8 @@ class TestObjectDoor(GenericTestDestinationDoor):
         "Text Pointer": "$ea82a5",
     }
 
-    def setup(self):
-        super(TestObjectDoor, self).setup()
+    def setUp(self):
+        super(TestObjectDoor, self).setUp()
         self.door = NpcDoor(x=251, y=123, type=self.DOOR_TYPE, text_address=0x00ea82a5)
 
 
@@ -219,8 +221,8 @@ class TestDoor(GenericTestDestinationDoor):
         "Text Pointer": "$c531af"
     }
 
-    def setup(self):
-        super(TestDoor, self).setup()
+    def setUp(self):
+        super(TestDoor, self).setUp()
         self.door = Door(x=222, y=111, text_address=0x00c531af, flag=0x231, destination_x=0x711,
                          destination_y=0x313, destination_direction=DestinationDirection.UP,
                          destination_style=0x42)

--- a/tests/model/eb/test_ebrom.py
+++ b/tests/model/eb/test_ebrom.py
@@ -1,12 +1,12 @@
 import hashlib
 from os import listdir
-from os.path import join
+from os.path import exists, join
 
-from nose.tools import assert_equal
+from unittest import skipUnless
 
 from coilsnake.model.common.blocks import Rom
 from coilsnake.model.eb.blocks import EbRom
-from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR
+from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR, earthbound_rom_available
 
 
 def is_rom_filename(fname):
@@ -14,20 +14,21 @@ def is_rom_filename(fname):
 
 
 class TestEbRom(BaseTestCase):
-
-    def setup(self):
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
+    def setUp(self):
         self.reference_rom = Rom()
         self.reference_rom.from_file(join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
 
-    def teardown(self):
+    def tearDown(self):
         del self.reference_rom
 
+    @skipUnless(exists(join(TEST_DATA_DIR, "roms", "variants")), "Variant ROM directory is missing")
     def test_fixing_rom_variants(self):
         for f in listdir(join(TEST_DATA_DIR, "roms", "variants")):
             if is_rom_filename(f):
                 variant = EbRom()
                 variant.from_file(join(TEST_DATA_DIR, "roms", "variants", f))
 
-                assert_equal(self.reference_rom.data, variant.data)
-                assert_equal(self.reference_rom.size, variant.size)
-                assert_equal(EbRom.REFERENCE_MD5, hashlib.md5(variant.data.tostring()).hexdigest())
+                self.assertEqual(self.reference_rom.data, variant.data)
+                self.assertEqual(self.reference_rom.size, variant.size)
+                self.assertEqual(EbRom.REFERENCE_MD5, hashlib.md5(variant.data.tobytes()).hexdigest())

--- a/tests/model/eb/test_enemy_groups.py
+++ b/tests/model/eb/test_enemy_groups.py
@@ -1,6 +1,3 @@
-from nose.tools import assert_list_equal, assert_tuple_equal, assert_dict_equal, assert_equal
-from nose.tools.nontrivial import raises
-
 from coilsnake.exceptions.common.exceptions import TableSchemaError
 from coilsnake.model.common.blocks import Block
 from coilsnake.model.eb.enemy_groups import MapEnemyGroupTableEntry
@@ -67,46 +64,46 @@ class TestMapEnemyGroupTableEntry(BaseTestCase):
             block = Block()
             block.from_list(test_case["block_rep"])
             value = MapEnemyGroupTableEntry.from_block(block, 0)
-            assert_tuple_equal(test_case["value_rep"], value)
+            self.assertTupleEqual(test_case["value_rep"], value)
 
     def test_to_block(self):
         for test_case in TEST_CASES:
             block_size = MapEnemyGroupTableEntry.to_block_size(test_case["value_rep"])
-            assert_equal(len(test_case["block_rep"]), block_size)
+            self.assertEqual(len(test_case["block_rep"]), block_size)
 
             block = Block(size=block_size)
             MapEnemyGroupTableEntry.to_block(block, 0, test_case["value_rep"])
-            assert_list_equal(test_case["block_rep"], block.to_list())
+            self.assertListEqual(test_case["block_rep"], block.to_list())
 
     def test_to_yml_rep(self):
         for test_case in TEST_CASES:
             yml_rep = MapEnemyGroupTableEntry.to_yml_rep(test_case["value_rep"])
-            assert_dict_equal(test_case["yml_rep"], yml_rep)
+            self.assertDictEqual(test_case["yml_rep"], yml_rep)
 
     def test_from_yml_rep(self):
         for test_case in TEST_CASES:
             value_rep = MapEnemyGroupTableEntry.from_yml_rep(test_case["yml_rep"])
-            assert_tuple_equal(test_case["value_rep"], value_rep)
+            self.assertTupleEqual(test_case["value_rep"], value_rep)
 
-    @raises(TableSchemaError)
     def test_from_yml_rep_low_probability(self):
-        MapEnemyGroupTableEntry.from_yml_rep(
-            {"Event Flag": 0x345,
-             "Sub-Group 1 Rate": 50,
-             "Sub-Group 2 Rate": 0,
-             "Sub-Group 1": {0: {"Probability": 7, "Enemy Group": 0x108}},
-             "Sub-Group 2": {}},
-        )
+        with self.assertRaises(TableSchemaError):
+            MapEnemyGroupTableEntry.from_yml_rep(
+                {"Event Flag": 0x345,
+                 "Sub-Group 1 Rate": 50,
+                 "Sub-Group 2 Rate": 0,
+                 "Sub-Group 1": {0: {"Probability": 7, "Enemy Group": 0x108}},
+                 "Sub-Group 2": {}},
+            )
 
-    @raises(TableSchemaError)
     def test_from_yml_rep_high_probability(self):
-        MapEnemyGroupTableEntry.from_yml_rep(
-            {"Event Flag": 0x345,
-             "Sub-Group 1 Rate": 50,
-             "Sub-Group 2 Rate": 0,
-             "Sub-Group 1": {0: {"Probability": 9, "Enemy Group": 0x108}},
-             "Sub-Group 2": {}},
-        )
+        with self.assertRaises(TableSchemaError):
+            MapEnemyGroupTableEntry.from_yml_rep(
+                {"Event Flag": 0x345,
+                 "Sub-Group 1 Rate": 50,
+                 "Sub-Group 2 Rate": 0,
+                 "Sub-Group 1": {0: {"Probability": 9, "Enemy Group": 0x108}},
+                 "Sub-Group 2": {}},
+            )
 
     def test_hex_labels(self):
-        assert_equal(["Event Flag"], MapEnemyGroupTableEntry.yml_rep_hex_labels())
+        self.assertEqual(["Event Flag"], MapEnemyGroupTableEntry.yml_rep_hex_labels())

--- a/tests/model/eb/test_graphics.py
+++ b/tests/model/eb/test_graphics.py
@@ -1,35 +1,34 @@
 from array import array
 
-from nose.tools import assert_equal, assert_raises, assert_list_equal, assert_false, assert_true, assert_is_instance, \
-    assert_not_equal, assert_set_equal, nottest
+from unittest import skip
 
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError
 from coilsnake.model.common.blocks import Block
 from coilsnake.model.eb.graphics import EbGraphicTileset, EbTileArrangementItem, EbTileArrangement
 from coilsnake.model.eb.palettes import EbPalette, EbColor
-from tests.coilsnake_test import BaseTestCase, TilesetImageTestCase, assert_images_equal
+from tests.coilsnake_test import BaseTestCase, TilesetImageTestCase
 
 
 class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
     def test_init(self):
         tileset = EbGraphicTileset(num_tiles=1, tile_width=8, tile_height=16)
-        assert_equal(tileset.num_tiles_maximum, 1)
-        assert_equal(tileset.tile_width, 8)
-        assert_equal(tileset.tile_height, 16)
+        self.assertEqual(tileset.num_tiles_maximum, 1)
+        self.assertEqual(tileset.tile_width, 8)
+        self.assertEqual(tileset.tile_height, 16)
 
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 0, 8, 8)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, -1, 8, 8)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 1, 0, 8)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 1, -1, 8)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 1, 1, 8)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 1, 8, 0)
-        assert_raises(InvalidArgumentError, EbGraphicTileset, 1, 8, -1)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 0, 8, 8)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, -1, 8, 8)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 1, 0, 8)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 1, -1, 8)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 1, 1, 8)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 1, 8, 0)
+        self.assertRaises(InvalidArgumentError, EbGraphicTileset, 1, 8, -1)
 
     def test_from_block_invalid(self):
         tileset = EbGraphicTileset(num_tiles=1, tile_width=8, tile_height=16)
         block = Block()
-        assert_raises(NotImplementedError, tileset.from_block, block, 0, 32)
-        assert_raises(NotImplementedError, tileset.from_block, block, 0, 2)
+        self.assertRaises(NotImplementedError, tileset.from_block, block, 0, 32)
+        self.assertRaises(NotImplementedError, tileset.from_block, block, 0, 2)
 
     def test_from_block_1bpp(self):
         block = Block()
@@ -51,7 +50,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                          0b00000001])
         tileset = EbGraphicTileset(num_tiles=2, tile_width=8, tile_height=8)
         tileset.from_block(block, offset=0, bpp=1)
-        assert_list_equal(tileset[0], [[0, 0, 0, 0, 0, 0, 1, 1],
+        self.assertListEqual(tileset[0], [[0, 0, 0, 0, 0, 0, 1, 1],
                                        [0, 1, 1, 1, 0, 0, 0, 0],
                                        [0, 1, 0, 0, 1, 0, 0, 1],
                                        [1, 1, 1, 1, 0, 0, 0, 0],
@@ -59,7 +58,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                                        [1, 1, 0, 0, 1, 0, 0, 0],
                                        [0, 1, 1, 1, 0, 0, 0, 1],
                                        [0, 0, 0, 0, 0, 0, 0, 1]])
-        assert_list_equal(tileset[1], [[0, 0, 1, 0, 0, 0, 0, 0],
+        self.assertListEqual(tileset[1], [[0, 0, 1, 0, 0, 0, 0, 0],
                                        [0, 0, 1, 1, 0, 0, 0, 0],
                                        [0, 0, 1, 0, 1, 0, 0, 0],
                                        [0, 0, 1, 0, 1, 0, 0, 0],
@@ -88,7 +87,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                          0b00000001])
         tileset = EbGraphicTileset(num_tiles=3, tile_width=8, tile_height=8)
         tileset.from_block(block, offset=0, bpp=1)
-        assert_list_equal(tileset[0], [[0, 0, 0, 0, 0, 0, 1, 1],
+        self.assertListEqual(tileset[0], [[0, 0, 0, 0, 0, 0, 1, 1],
                                        [0, 1, 1, 1, 0, 0, 0, 0],
                                        [0, 1, 0, 0, 1, 0, 0, 1],
                                        [1, 1, 1, 1, 0, 0, 0, 0],
@@ -96,7 +95,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                                        [1, 1, 0, 0, 1, 0, 0, 0],
                                        [0, 1, 1, 1, 0, 0, 0, 1],
                                        [0, 0, 0, 0, 0, 0, 0, 1]])
-        assert_list_equal(tileset[1], [[0, 0, 1, 0, 0, 0, 0, 0],
+        self.assertListEqual(tileset[1], [[0, 0, 1, 0, 0, 0, 0, 0],
                                        [0, 0, 1, 1, 0, 0, 0, 0],
                                        [0, 0, 1, 0, 1, 0, 0, 0],
                                        [0, 0, 1, 0, 1, 0, 0, 0],
@@ -104,7 +103,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                                        [1, 1, 1, 0, 0, 0, 0, 0],
                                        [1, 1, 0, 0, 0, 0, 0, 0],
                                        [0, 0, 0, 0, 0, 0, 0, 1]])
-        assert_list_equal(tileset[2], [[0, 0, 0, 0, 0, 0, 0, 0],
+        self.assertListEqual(tileset[2], [[0, 0, 0, 0, 0, 0, 0, 0],
                                        [0, 0, 0, 0, 0, 0, 0, 0],
                                        [0, 0, 0, 0, 0, 0, 0, 0],
                                        [0, 0, 0, 0, 0, 0, 0, 0],
@@ -149,7 +148,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                          0b11110000])
         tileset = EbGraphicTileset(num_tiles=2, tile_width=8, tile_height=8)
         tileset.from_block(block, offset=0, bpp=2)
-        assert_list_equal(tileset[0], [[2, 1, 2, 3, 2, 1, 2, 1],
+        self.assertListEqual(tileset[0], [[2, 1, 2, 3, 2, 1, 2, 1],
                                        [2, 3, 1, 0, 2, 3, 2, 2],
                                        [3, 0, 3, 2, 2, 2, 0, 2],
                                        [1, 3, 3, 0, 2, 0, 2, 3],
@@ -157,7 +156,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                                        [1, 3, 3, 3, 3, 2, 1, 2],
                                        [2, 2, 3, 1, 2, 2, 1, 0],
                                        [2, 0, 3, 3, 2, 3, 1, 0]])
-        assert_list_equal(tileset[1], [[1, 3, 3, 1, 3, 0, 2, 1],
+        self.assertListEqual(tileset[1], [[1, 3, 3, 1, 3, 0, 2, 1],
                                        [3, 2, 2, 3, 3, 2, 2, 2],
                                        [1, 1, 2, 2, 3, 0, 1, 1],
                                        [0, 3, 2, 2, 0, 0, 0, 3],
@@ -217,7 +216,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                          0b11101110])
         tileset = EbGraphicTileset(num_tiles=1, tile_width=8, tile_height=8)
         tileset.from_block(block, offset=0, bpp=4)
-        assert_list_equal(tileset[0], [[8, 1, 12, 9, 6, 5, 3, 2],
+        self.assertListEqual(tileset[0], [[8, 1, 12, 9, 6, 5, 3, 2],
                                        [11, 5, 8, 14, 1, 7, 15, 0],
                                        [8, 13, 3, 7, 2, 0, 2, 3],
                                        [10, 0, 4, 14, 7, 10, 11, 9],
@@ -230,8 +229,8 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
     def test_to_block_invalid(self):
         tileset = EbGraphicTileset(num_tiles=1, tile_width=8, tile_height=16)
         block = Block()
-        assert_raises(NotImplementedError, tileset.to_block, block, 0, 32)
-        assert_raises(NotImplementedError, tileset.to_block, block, 0, 2)
+        self.assertRaises(NotImplementedError, tileset.to_block, block, 0, 32)
+        self.assertRaises(NotImplementedError, tileset.to_block, block, 0, 2)
 
     def test_to_block_1bpp(self):
         tileset = EbGraphicTileset(num_tiles=2, tile_width=8, tile_height=8)
@@ -255,7 +254,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
         block = Block()
         block.from_list([0] * 16)
         tileset.to_block(block, 0, 1)
-        assert_list_equal(block.to_list(), [0b00000011,
+        self.assertListEqual(block.to_list(), [0b00000011,
                                             0b01110000,
                                             0b01001001,
                                             0b11110000,
@@ -294,7 +293,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
         block = Block()
         block.from_list([0] * 32)
         tileset.to_block(block, 0, 2)
-        assert_list_equal(block.to_list(), [0b01010101,  # Tile 1
+        self.assertListEqual(block.to_list(), [0b01010101,  # Tile 1
                                             0b10111010,
                                             0b01100100,
                                             0b11001111,
@@ -341,7 +340,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
         block = Block()
         block.from_list([0] * 32)
         tileset.to_block(block, 0, 4)
-        assert_list_equal(block.to_list(), [0b01010110,
+        self.assertListEqual(block.to_list(), [0b01010110,
                                             0b00001011,
 
                                             0b11001110,
@@ -390,13 +389,13 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                                             0b11101110])
 
     def test_block_size(self):
-        assert_equal(EbGraphicTileset(num_tiles=2, tile_width=8, tile_height=8).block_size(2), 32)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(2), 160)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(4), 320)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(8), 640)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(1), 80)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=16).block_size(1), 160)
-        assert_equal(EbGraphicTileset(num_tiles=10, tile_width=16, tile_height=16).block_size(1), 320)
+        self.assertEqual(EbGraphicTileset(num_tiles=2, tile_width=8, tile_height=8).block_size(2), 32)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(2), 160)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(4), 320)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(8), 640)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=8).block_size(1), 80)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=8, tile_height=16).block_size(1), 160)
+        self.assertEqual(EbGraphicTileset(num_tiles=10, tile_width=16, tile_height=16).block_size(1), 320)
 
     def test_from_image_8x8_1bpp(self):
         palette = EbPalette(1, 2)
@@ -411,9 +410,9 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
 
         tileset = EbGraphicTileset(num_tiles=4, tile_width=8, tile_height=8)
         tileset.from_image(self.tile_8x8_2bpp_img, arrangement=arrangement, palette=palette)
-        assert_list_equal(tileset[0], [[0] * 8] * 8)
-        assert_list_equal(tileset[2], [[1] * 8] * 8)
-        assert_list_equal(tileset[1],
+        self.assertListEqual(tileset[0], [[0] * 8] * 8)
+        self.assertListEqual(tileset[2], [[1] * 8] * 8)
+        self.assertListEqual(tileset[1],
                           [[0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 1, 1, 1, 1, 0, 0],
@@ -422,7 +421,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                            [0, 0, 1, 1, 1, 1, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0]])
-        assert_list_equal(tileset[3],
+        self.assertListEqual(tileset[3],
                           [[0, 1, 1, 1, 1, 1, 1, 1],
                            [0, 1, 1, 1, 1, 1, 1, 1],
                            [0, 1, 0, 0, 0, 0, 1, 1],
@@ -450,9 +449,9 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
         tileset = EbGraphicTileset(num_tiles=5, tile_width=8, tile_height=16)
         tileset.from_image(self.tile_8x16_4bpp_img, arrangement=arrangement, palette=palette)
 
-        assert_list_equal(tileset[1], [[2] * 8] * 16)
-        assert_list_equal(tileset[3], [[3] * 8] * 16)
-        assert_list_equal(tileset[2],
+        self.assertListEqual(tileset[1], [[2] * 8] * 16)
+        self.assertListEqual(tileset[3], [[3] * 8] * 16)
+        self.assertListEqual(tileset[2],
                           [[3] * 8,
                            [3] * 8,
                            [3] * 8,
@@ -469,7 +468,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                            [1] * 8,
                            [1] * 8,
                            [1, 1, 1, 3, 1, 1, 1, 1]])
-        assert_list_equal(tileset[0],
+        self.assertListEqual(tileset[0],
                           [[2, 1, 1, 1, 1, 1, 1, 1],
                            [2, 3, 3, 3, 3, 3, 3, 1],
                            [0, 2, 3, 3, 3, 3, 1, 3],
@@ -486,7 +485,7 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                            [0, 1, 0, 0, 0, 0, 2, 3],
                            [1, 0, 0, 0, 0, 0, 0, 2],
                            [1, 0, 0, 0, 0, 0, 0, 2]])
-        assert_list_equal(tileset[4],
+        self.assertListEqual(tileset[4],
                           [[3] * 8,
                            [3] * 8,
                            [3] * 8,
@@ -517,28 +516,28 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
         tile1_id, tile1_vflip, tile1_hflip = tileset.add_tile(tile)
 
         tile2_id, tile2_vflip, tile2_hflip = tileset.add_tile(tile)
-        assert_equal(tile2_id, tile1_id)
-        assert_equal(tile2_vflip, tile1_vflip)
-        assert_equal(tile2_hflip, tile1_hflip)
+        self.assertEqual(tile2_id, tile1_id)
+        self.assertEqual(tile2_vflip, tile1_vflip)
+        self.assertEqual(tile2_hflip, tile1_hflip)
 
         tile.reverse()
         tile2_id, tile2_vflip, tile2_hflip = tileset.add_tile(tile)
-        assert_equal(tile2_id, tile1_id)
-        assert_equal(tile2_vflip, not tile1_vflip)
-        assert_equal(tile2_hflip, tile1_hflip)
+        self.assertEqual(tile2_id, tile1_id)
+        self.assertEqual(tile2_vflip, not tile1_vflip)
+        self.assertEqual(tile2_hflip, tile1_hflip)
 
         for row in tile:
             row.reverse()
         tile2_id, tile2_vflip, tile2_hflip = tileset.add_tile(tile)
-        assert_equal(tile2_id, tile1_id)
-        assert_equal(tile2_vflip, not tile1_vflip)
-        assert_equal(tile2_hflip, not tile1_hflip)
+        self.assertEqual(tile2_id, tile1_id)
+        self.assertEqual(tile2_vflip, not tile1_vflip)
+        self.assertEqual(tile2_hflip, not tile1_hflip)
 
         tile.reverse()
         tile2_id, tile2_vflip, tile2_hflip = tileset.add_tile(tile)
-        assert_equal(tile2_id, tile1_id)
-        assert_equal(tile2_vflip, tile1_vflip)
-        assert_equal(tile2_hflip, not tile1_hflip)
+        self.assertEqual(tile2_id, tile1_id)
+        self.assertEqual(tile2_vflip, tile1_vflip)
+        self.assertEqual(tile2_hflip, not tile1_hflip)
 
         tile = [array('B', [1, 2, 3, 4, 1, 5, 3, 3]),
                 array('B', [5, 8, 3, 7, 5, 7, 1, 1]),
@@ -549,25 +548,25 @@ class TestEbGraphicTileset(BaseTestCase, TilesetImageTestCase):
                 array('B', [8, 0, 4, 0, 2, 8, 0, 8]),
                 array('B', [0, 6, 8, 6, 0, 5, 4, 0])]
         tile2_id, tile2_vflip, tile2_hflip = tileset.add_tile(tile)
-        assert_not_equal(tile2_id, tile1_id)
+        self.assertNotEqual(tile2_id, tile1_id)
 
 
 class TestEbTileArrangementItem(BaseTestCase):
     def test_init(self):
         arrangement_item = EbTileArrangementItem(tile=12, subpalette=3, is_vertically_flipped=False,
                                                  is_horizontally_flipped=True, is_priority=True)
-        assert_equal(arrangement_item.tile, 12)
-        assert_equal(arrangement_item.subpalette, 3)
-        assert_false(arrangement_item.is_vertically_flipped, False)
-        assert_true(arrangement_item.is_horizontally_flipped, True)
-        assert_true(arrangement_item.is_priority, True)
+        self.assertEqual(arrangement_item.tile, 12)
+        self.assertEqual(arrangement_item.subpalette, 3)
+        self.assertFalse(arrangement_item.is_vertically_flipped)
+        self.assertTrue(arrangement_item.is_horizontally_flipped)
+        self.assertTrue(arrangement_item.is_priority)
 
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, -1, 0)
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, 0, -1)
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, -1, -1)
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, 0x400, 0)
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, 0, 8)
-        assert_raises(InvalidArgumentError, EbTileArrangementItem, 0x400, 8)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, -1, 0)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, 0, -1)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, -1, -1)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, 0x400, 0)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, 0, 8)
+        self.assertRaises(InvalidArgumentError, EbTileArrangementItem, 0x400, 8)
 
     def test_from_block(self):
         arrangement_item = EbTileArrangementItem()
@@ -576,19 +575,19 @@ class TestEbTileArrangementItem(BaseTestCase):
 
         block.write_multi(0, 0x8000 | 0x2000 | (7 << 10) | 0x120, 2)
         arrangement_item.from_block(block, 0)
-        assert_true(arrangement_item.is_vertically_flipped)
-        assert_false(arrangement_item.is_horizontally_flipped)
-        assert_true(arrangement_item.is_priority, True)
-        assert_equal(arrangement_item.subpalette, 7)
-        assert_equal(arrangement_item.tile, 0x120)
+        self.assertTrue(arrangement_item.is_vertically_flipped)
+        self.assertFalse(arrangement_item.is_horizontally_flipped)
+        self.assertTrue(arrangement_item.is_priority)
+        self.assertEqual(arrangement_item.subpalette, 7)
+        self.assertEqual(arrangement_item.tile, 0x120)
 
         block.write_multi(1, 0x4000 | (2 << 10) | 0x3f5, 2)
         arrangement_item.from_block(block, 1)
-        assert_false(arrangement_item.is_vertically_flipped)
-        assert_true(arrangement_item.is_horizontally_flipped)
-        assert_false(arrangement_item.is_priority)
-        assert_equal(arrangement_item.subpalette, 2)
-        assert_equal(arrangement_item.tile, 0x3f5)
+        self.assertFalse(arrangement_item.is_vertically_flipped)
+        self.assertTrue(arrangement_item.is_horizontally_flipped)
+        self.assertFalse(arrangement_item.is_priority)
+        self.assertEqual(arrangement_item.subpalette, 2)
+        self.assertEqual(arrangement_item.tile, 0x3f5)
 
     def test_to_block(self):
         arrangement_item = EbTileArrangementItem()
@@ -601,7 +600,7 @@ class TestEbTileArrangementItem(BaseTestCase):
         arrangement_item.subpalette = 7
         arrangement_item.tile = 0x120
         arrangement_item.to_block(block, 0)
-        assert_equal(block.read_multi(0, 2), 0x8000 | 0x2000 | (7 << 10) | 0x120)
+        self.assertEqual(block.read_multi(0, 2), 0x8000 | 0x2000 | (7 << 10) | 0x120)
 
         arrangement_item.is_vertically_flipped = False
         arrangement_item.is_horizontally_flipped = True
@@ -609,21 +608,21 @@ class TestEbTileArrangementItem(BaseTestCase):
         arrangement_item.subpalette = 2
         arrangement_item.tile = 0x3f5
         arrangement_item.to_block(block, 1)
-        assert_equal(block.read_multi(1, 2), 0x4000 | (2 << 10) | 0x3f5)
+        self.assertEqual(block.read_multi(1, 2), 0x4000 | (2 << 10) | 0x3f5)
 
 
 class TestEbTileArrangement(BaseTestCase, TilesetImageTestCase):
     def test_init(self):
         arrangement = EbTileArrangement(32, 28)
-        assert_equal(arrangement.width, 32)
-        assert_equal(arrangement.height, 28)
+        self.assertEqual(arrangement.width, 32)
+        self.assertEqual(arrangement.height, 28)
 
-        assert_raises(InvalidArgumentError, EbTileArrangement, 0, 32)
-        assert_raises(InvalidArgumentError, EbTileArrangement, -1, 32)
-        assert_raises(InvalidArgumentError, EbTileArrangement, 32, 0)
-        assert_raises(InvalidArgumentError, EbTileArrangement, 32, -1)
-        assert_raises(InvalidArgumentError, EbTileArrangement, 0, 0)
-        assert_raises(InvalidArgumentError, EbTileArrangement, -1, -1)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, 0, 32)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, -1, 32)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, 32, 0)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, 32, -1)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, 0, 0)
+        self.assertRaises(InvalidArgumentError, EbTileArrangement, -1, -1)
 
     def test_from_block(self):
         block = Block()
@@ -634,45 +633,45 @@ class TestEbTileArrangement(BaseTestCase, TilesetImageTestCase):
         arrangement = EbTileArrangement(2, 1)
         arrangement.from_block(block, 1)
 
-        assert_true(arrangement[0, 0].is_vertically_flipped)
-        assert_false(arrangement[0, 0].is_horizontally_flipped)
-        assert_true(arrangement[0, 0].is_priority, True)
-        assert_equal(arrangement[0, 0].subpalette, 7)
-        assert_equal(arrangement[0, 0].tile, 0x120)
+        self.assertTrue(arrangement[0, 0].is_vertically_flipped)
+        self.assertFalse(arrangement[0, 0].is_horizontally_flipped)
+        self.assertTrue(arrangement[0, 0].is_priority)
+        self.assertEqual(arrangement[0, 0].subpalette, 7)
+        self.assertEqual(arrangement[0, 0].tile, 0x120)
 
-        assert_false(arrangement[1, 0].is_vertically_flipped)
-        assert_true(arrangement[1, 0].is_horizontally_flipped)
-        assert_false(arrangement[1, 0].is_priority)
-        assert_equal(arrangement[1, 0].subpalette, 2)
-        assert_equal(arrangement[1, 0].tile, 0x3f5)
+        self.assertFalse(arrangement[1, 0].is_vertically_flipped)
+        self.assertTrue(arrangement[1, 0].is_horizontally_flipped)
+        self.assertFalse(arrangement[1, 0].is_priority)
+        self.assertEqual(arrangement[1, 0].subpalette, 2)
+        self.assertEqual(arrangement[1, 0].tile, 0x3f5)
 
         arrangement = EbTileArrangement(1, 2)
         arrangement.from_block(block, 1)
 
-        assert_true(arrangement[0, 0].is_vertically_flipped)
-        assert_false(arrangement[0, 0].is_horizontally_flipped)
-        assert_true(arrangement[0, 0].is_priority, True)
-        assert_equal(arrangement[0, 0].subpalette, 7)
-        assert_equal(arrangement[0, 0].tile, 0x120)
+        self.assertTrue(arrangement[0, 0].is_vertically_flipped)
+        self.assertFalse(arrangement[0, 0].is_horizontally_flipped)
+        self.assertTrue(arrangement[0, 0].is_priority)
+        self.assertEqual(arrangement[0, 0].subpalette, 7)
+        self.assertEqual(arrangement[0, 0].tile, 0x120)
 
-        assert_false(arrangement[0, 1].is_vertically_flipped)
-        assert_true(arrangement[0, 1].is_horizontally_flipped)
-        assert_false(arrangement[0, 1].is_priority)
-        assert_equal(arrangement[0, 1].subpalette, 2)
-        assert_equal(arrangement[0, 1].tile, 0x3f5)
+        self.assertFalse(arrangement[0, 1].is_vertically_flipped)
+        self.assertTrue(arrangement[0, 1].is_horizontally_flipped)
+        self.assertFalse(arrangement[0, 1].is_priority)
+        self.assertEqual(arrangement[0, 1].subpalette, 2)
+        self.assertEqual(arrangement[0, 1].tile, 0x3f5)
 
     def test_getitem(self):
         arrangement = EbTileArrangement(2, 1)
-        assert_is_instance(arrangement[0, 0], EbTileArrangementItem)
-        assert_is_instance(arrangement[1, 0], EbTileArrangementItem)
+        self.assertIsInstance(arrangement[0, 0], EbTileArrangementItem)
+        self.assertIsInstance(arrangement[1, 0], EbTileArrangementItem)
 
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (-1, 0))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (0, -1))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (-1, -1))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (0, 1))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (0, 2))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (1, 2))
-        assert_raises(InvalidArgumentError, arrangement.__getitem__, (3, 0))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (-1, 0))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (0, -1))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (-1, -1))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (0, 1))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (0, 2))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (1, 2))
+        self.assertRaises(InvalidArgumentError, arrangement.__getitem__, (3, 0))
 
     def test_from_image_single_subpalette(self):
         palette = EbPalette(1, 2)
@@ -680,36 +679,36 @@ class TestEbTileArrangement(BaseTestCase, TilesetImageTestCase):
         arrangement = EbTileArrangement(width=6, height=1)
         arrangement.from_image(self.tile_8x8_2bpp_2_img, tileset=tileset, palette=palette)
 
-        assert_equal(palette[0, 0], EbColor(0, 0, 0))
-        assert_equal(palette[0, 1], EbColor(0xf8, 0xf8, 0xf8))
+        self.assertEqual(palette[0, 0], EbColor(0, 0, 0))
+        self.assertEqual(palette[0, 1], EbColor(0xf8, 0xf8, 0xf8))
 
         item = arrangement[0, 0]
-        assert_equal(item.subpalette, 0)
+        self.assertEqual(item.subpalette, 0)
 
-        assert_equal(arrangement[1, 0].tile, item.tile)
-        assert_equal(arrangement[1, 0].is_horizontally_flipped, not item.is_horizontally_flipped)
-        assert_equal(arrangement[1, 0].is_vertically_flipped, item.is_vertically_flipped)
-        assert_equal(arrangement[1, 0].subpalette, 0)
+        self.assertEqual(arrangement[1, 0].tile, item.tile)
+        self.assertEqual(arrangement[1, 0].is_horizontally_flipped, not item.is_horizontally_flipped)
+        self.assertEqual(arrangement[1, 0].is_vertically_flipped, item.is_vertically_flipped)
+        self.assertEqual(arrangement[1, 0].subpalette, 0)
 
-        assert_equal(arrangement[2, 0].tile, item.tile)
-        assert_equal(arrangement[2, 0].is_horizontally_flipped, item.is_horizontally_flipped)
-        assert_equal(arrangement[2, 0].is_vertically_flipped, not item.is_vertically_flipped)
-        assert_equal(arrangement[2, 0].subpalette, 0)
+        self.assertEqual(arrangement[2, 0].tile, item.tile)
+        self.assertEqual(arrangement[2, 0].is_horizontally_flipped, item.is_horizontally_flipped)
+        self.assertEqual(arrangement[2, 0].is_vertically_flipped, not item.is_vertically_flipped)
+        self.assertEqual(arrangement[2, 0].subpalette, 0)
 
-        assert_equal(arrangement[3, 0].tile, item.tile)
-        assert_equal(arrangement[3, 0].is_horizontally_flipped, not item.is_horizontally_flipped)
-        assert_equal(arrangement[2, 0].is_vertically_flipped, not item.is_vertically_flipped)
-        assert_equal(arrangement[3, 0].subpalette, 0)
+        self.assertEqual(arrangement[3, 0].tile, item.tile)
+        self.assertEqual(arrangement[3, 0].is_horizontally_flipped, not item.is_horizontally_flipped)
+        self.assertEqual(arrangement[2, 0].is_vertically_flipped, not item.is_vertically_flipped)
+        self.assertEqual(arrangement[3, 0].subpalette, 0)
 
-        assert_not_equal(arrangement[4, 0].tile, item.tile)
-        assert_equal(arrangement[4, 0].subpalette, 0)
+        self.assertNotEqual(arrangement[4, 0].tile, item.tile)
+        self.assertEqual(arrangement[4, 0].subpalette, 0)
 
-        assert_equal(arrangement[5, 0].tile, item.tile)
-        assert_equal(arrangement[5, 0].is_horizontally_flipped, item.is_horizontally_flipped)
-        assert_equal(arrangement[5, 0].is_vertically_flipped, item.is_vertically_flipped)
-        assert_equal(arrangement[5, 0].subpalette, 0)
+        self.assertEqual(arrangement[5, 0].tile, item.tile)
+        self.assertEqual(arrangement[5, 0].is_horizontally_flipped, item.is_horizontally_flipped)
+        self.assertEqual(arrangement[5, 0].is_vertically_flipped, item.is_vertically_flipped)
+        self.assertEqual(arrangement[5, 0].subpalette, 0)
 
-    @nottest
+    @skip("marked as 'not test' for some reason")
     def test_from_image_2_subpalettes(self):
         palette = EbPalette(2, 4)
         tileset = EbGraphicTileset(num_tiles=4, tile_width=8, tile_height=8)
@@ -720,26 +719,26 @@ class TestEbTileArrangement(BaseTestCase, TilesetImageTestCase):
         self.tile_8x8_2bpp_3_img.putpalette([x & 0xf8 for x in img_palette])
         before_image_rgb = self.tile_8x8_2bpp_3_img.convert("RGB")
         after_image_rgb = arrangement.image(tileset, palette).convert("RGB")
-        assert_images_equal(before_image_rgb, after_image_rgb)
+        self.assert_images_equal(before_image_rgb, after_image_rgb)
 
-        assert_set_equal({palette[1, i] for i in range(4)},
+        self.assertSetEqual({palette[1, i] for i in range(4)},
                          {EbColor(24, 0, 248), EbColor(0, 248, 24), EbColor(152, 0, 248), EbColor(248, 144, 0)})
-        assert_set_equal({palette[0, i] for i in range(4)},
+        self.assertSetEqual({palette[0, i] for i in range(4)},
                          {EbColor(24, 0, 248), EbColor(0, 248, 24), EbColor(216, 248, 0), EbColor(152, 0, 248)})
 
-        assert_equal(arrangement[0, 0].tile, 0)
-        assert_equal(arrangement[0, 0].subpalette, 0)
-        assert_equal({tileset[0][0][i] for i in [-1, -2, -3, -4]}, {0, 1, 2, 3})
+        self.assertEqual(arrangement[0, 0].tile, 0)
+        self.assertEqual(arrangement[0, 0].subpalette, 0)
+        self.assertEqual({tileset[0][0][i] for i in [-1, -2, -3, -4]}, {0, 1, 2, 3})
 
-        assert_equal(arrangement[1, 0].tile, 1)
-        assert_equal(arrangement[1, 0].subpalette, 1)
-        assert_equal({tileset[1][0][i] for i in [-1, -2, -3, -4]}, {0, 1, 2, 3})
+        self.assertEqual(arrangement[1, 0].tile, 1)
+        self.assertEqual(arrangement[1, 0].subpalette, 1)
+        self.assertEqual({tileset[1][0][i] for i in [-1, -2, -3, -4]}, {0, 1, 2, 3})
 
-        assert_equal(arrangement[2, 0].tile, 2)
-        assert_equal(arrangement[2, 0].subpalette, 0)
+        self.assertEqual(arrangement[2, 0].tile, 2)
+        self.assertEqual(arrangement[2, 0].subpalette, 0)
 
-        assert_equal(arrangement[3, 0].tile, 3)
-        assert_equal(arrangement[3, 0].subpalette, 1)
+        self.assertEqual(arrangement[3, 0].tile, 3)
+        self.assertEqual(arrangement[3, 0].subpalette, 1)
 
     def test_to_image_single_subpalette(self):
         palette = EbPalette(1, 2)
@@ -748,4 +747,4 @@ class TestEbTileArrangement(BaseTestCase, TilesetImageTestCase):
         arrangement.from_image(self.tile_8x8_2bpp_2_img, tileset=tileset, palette=palette)
 
         new_image = arrangement.image(tileset, palette)
-        assert_images_equal(self.tile_8x8_2bpp_2_img, new_image)
+        self.assert_images_equal(self.tile_8x8_2bpp_2_img, new_image)

--- a/tests/model/eb/test_palettes.py
+++ b/tests/model/eb/test_palettes.py
@@ -1,5 +1,6 @@
 from PIL import Image
-from nose.tools import assert_equal, assert_set_equal, assert_list_equal, assert_raises, assert_true, assert_false, raises
+
+from unittest import skip
 
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError
 from coilsnake.model.common.blocks import Block
@@ -8,27 +9,27 @@ from tests.coilsnake_test import BaseTestCase, TilesetImageTestCase
 
 
 class TestEbColor(BaseTestCase):
-    def setup(self):
+    def setUp(self):
         self.color = EbColor()
 
     def test_init(self):
         color2 = EbColor(r=3, g=255, b=84)
-        assert_equal(color2.r, 3)
-        assert_equal(color2.g, 255)
-        assert_equal(color2.b, 84)
+        self.assertEqual(color2.r, 3)
+        self.assertEqual(color2.g, 255)
+        self.assertEqual(color2.b, 84)
 
     def test_init_default(self):
-        assert_equal(self.color.r, 0)
-        assert_equal(self.color.g, 0)
-        assert_equal(self.color.b, 0)
+        self.assertEqual(self.color.r, 0)
+        self.assertEqual(self.color.g, 0)
+        self.assertEqual(self.color.b, 0)
 
     def test_from_block(self):
         block = Block()
         block.from_list([0x5f, 0x0a])
         self.color.from_block(block, 0)
-        assert_equal(self.color.r, 248)
-        assert_equal(self.color.g, 144)
-        assert_equal(self.color.b, 16)
+        self.assertEqual(self.color.r, 248)
+        self.assertEqual(self.color.g, 144)
+        self.assertEqual(self.color.b, 16)
 
     def test_to_block(self):
         block = Block()
@@ -37,84 +38,84 @@ class TestEbColor(BaseTestCase):
         self.color.g = 144
         self.color.b = 16
         self.color.to_block(block, 0)
-        assert_list_equal(block.to_list(), [0x5f, 0x0a])
+        self.assertListEqual(block.to_list(), [0x5f, 0x0a])
 
     def test_from_tuple(self):
         self.color.from_tuple((20, 40, 69))
-        assert_equal(self.color.r, 20)
-        assert_equal(self.color.g, 40)
-        assert_equal(self.color.b, 69)
+        self.assertEqual(self.color.r, 20)
+        self.assertEqual(self.color.g, 40)
+        self.assertEqual(self.color.b, 69)
 
     def test_tuple(self):
         self.color.from_tuple((20, 40, 69))
-        assert_equal(self.color.tuple(), (20, 40, 69))
+        self.assertEqual(self.color.tuple(), (20, 40, 69))
 
     def test_from_list(self):
         self.color.from_list([20, 40, 69])
-        assert_equal(self.color.tuple(), (16, 40, 64))
+        self.assertEqual(self.color.tuple(), (16, 40, 64))
 
         self.color.from_list([55, 44, 33, 20, 40, 69], offset=2)
-        assert_equal(self.color.tuple(), (32, 16, 40))
+        self.assertEqual(self.color.tuple(), (32, 16, 40))
 
     def test_to_list(self):
         self.color.from_tuple((20, 40, 69))
         test_list = [0] * 5
         self.color.to_list(test_list)
-        assert_list_equal(test_list, [20, 40, 69, 0, 0])
+        self.assertListEqual(test_list, [20, 40, 69, 0, 0])
         self.color.to_list(test_list, 2)
-        assert_list_equal(test_list, [20, 40, 20, 40, 69])
+        self.assertListEqual(test_list, [20, 40, 20, 40, 69])
 
     def test_list(self):
         self.color.from_tuple((20, 40, 69))
-        assert_equal(self.color.list(), [20, 40, 69])
+        self.assertEqual(self.color.list(), [20, 40, 69])
 
 
 class TestEbPalette(BaseTestCase, TilesetImageTestCase):
-    def setup(self):
-        super(TestEbPalette, self).setup()
+    def setUp(self):
+        super(TestEbPalette, self).setUp()
         self.palette = EbPalette(2, 3)
 
     def test_init(self):
-        assert_equal(self.palette.num_subpalettes, 2)
-        assert_equal(self.palette.subpalette_length, 3)
+        self.assertEqual(self.palette.num_subpalettes, 2)
+        self.assertEqual(self.palette.subpalette_length, 3)
 
     def test_init_invalid(self):
-        assert_raises(InvalidArgumentError, EbPalette, 0, 1)
-        assert_raises(InvalidArgumentError, EbPalette, -1, 1)
-        assert_raises(InvalidArgumentError, EbPalette, 1, 0)
-        assert_raises(InvalidArgumentError, EbPalette, 1, -1)
-        assert_raises(InvalidArgumentError, EbPalette, 0, 0)
-        assert_raises(InvalidArgumentError, EbPalette, -1, -1)
+        self.assertRaises(InvalidArgumentError, EbPalette, 0, 1)
+        self.assertRaises(InvalidArgumentError, EbPalette, -1, 1)
+        self.assertRaises(InvalidArgumentError, EbPalette, 1, 0)
+        self.assertRaises(InvalidArgumentError, EbPalette, 1, -1)
+        self.assertRaises(InvalidArgumentError, EbPalette, 0, 0)
+        self.assertRaises(InvalidArgumentError, EbPalette, -1, -1)
 
     def test_num_colors(self):
-        assert_equal(self.palette.num_colors(), 6)
+        self.assertEqual(self.palette.num_colors(), 6)
 
     def test_getitem(self):
-        assert_equal(self.palette[0, 0].tuple(), (0, 0, 0))
-        assert_equal(self.palette[0, 1].tuple(), (0, 0, 0))
+        self.assertEqual(self.palette[0, 0].tuple(), (0, 0, 0))
+        self.assertEqual(self.palette[0, 1].tuple(), (0, 0, 0))
         self.palette[0, 1].from_tuple((8, 16, 32))
-        assert_equal(self.palette[0, 0].tuple(), (0, 0, 0))
-        assert_equal(self.palette[0, 1].tuple(), (8, 16, 32))
+        self.assertEqual(self.palette[0, 0].tuple(), (0, 0, 0))
+        self.assertEqual(self.palette[0, 1].tuple(), (8, 16, 32))
 
     def test_getitem_invalid(self):
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (-1, 0))
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (0, -1))
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (-1, -1))
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (2, 0))
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (0, 3))
-        assert_raises(InvalidArgumentError, self.palette.__getitem__, (2, 3))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (-1, 0))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (0, -1))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (-1, -1))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (2, 0))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (0, 3))
+        self.assertRaises(InvalidArgumentError, self.palette.__getitem__, (2, 3))
 
     def test_from_list(self):
         self.palette.from_list([
             0, 0, 0, 40, 8, 72, 80, 88, 48,
             248, 0, 0, 80, 56, 40, 16, 136, 136
         ])
-        assert_equal(self.palette[0, 0].tuple(), (0, 0, 0))
-        assert_equal(self.palette[0, 1].tuple(), (40, 8, 72))
-        assert_equal(self.palette[0, 2].tuple(), (80, 88, 48))
-        assert_equal(self.palette[1, 0].tuple(), (248, 0, 0))
-        assert_equal(self.palette[1, 1].tuple(), (80, 56, 40))
-        assert_equal(self.palette[1, 2].tuple(), (16, 136, 136))
+        self.assertEqual(self.palette[0, 0].tuple(), (0, 0, 0))
+        self.assertEqual(self.palette[0, 1].tuple(), (40, 8, 72))
+        self.assertEqual(self.palette[0, 2].tuple(), (80, 88, 48))
+        self.assertEqual(self.palette[1, 0].tuple(), (248, 0, 0))
+        self.assertEqual(self.palette[1, 1].tuple(), (80, 56, 40))
+        self.assertEqual(self.palette[1, 2].tuple(), (16, 136, 136))
 
     def test_to_list(self):
         self.palette[0, 0].from_tuple((0, 0, 0))
@@ -123,7 +124,7 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
         self.palette[1, 0].from_tuple((248, 0, 0))
         self.palette[1, 1].from_tuple((80, 56, 40))
         self.palette[1, 2].from_tuple((16, 136, 136))
-        assert_list_equal(self.palette.list(), [0, 0, 0, 40, 8, 72, 80, 88, 48,
+        self.assertListEqual(self.palette.list(), [0, 0, 0, 40, 8, 72, 80, 88, 48,
                                                 248, 0, 0, 80, 56, 40, 16, 136, 136])
 
     def test_from_block(self):
@@ -131,7 +132,7 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
         block.from_list([0, 0, 37, 36, 106, 25,
                          31, 0, 234, 20, 34, 70])
         self.palette.from_block(block)
-        assert_list_equal(self.palette.list(), [
+        self.assertListEqual(self.palette.list(), [
             0, 0, 0, 40, 8, 72, 80, 88, 48,
             248, 0, 0, 80, 56, 40, 16, 136, 136
         ])
@@ -144,12 +145,12 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
         block = Block()
         block.from_list([0xff] * 50)
         self.palette.to_block(block, offset=1)
-        assert_list_equal(block[0:14].to_list(), [0xff, 0, 0, 37, 36, 106, 25,
+        self.assertListEqual(block[0:14].to_list(), [0xff, 0, 0, 37, 36, 106, 25,
                                                   31, 0, 234, 20, 34, 70, 0xff])
 
     def test_from_image(self):
         self.palette.from_image(self.tile_image_01_img)
-        assert_list_equal(self.palette.list(),
+        self.assertListEqual(self.palette.list(),
                           [0x00, 0x00, 0x00,
                            0x08, 0x00, 0xf8,
                            0xf8, 0x00, 0x00,
@@ -166,7 +167,7 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
         self.palette[1, 1].from_tuple((80, 56, 40))
         self.palette[1, 2].from_tuple((16, 136, 136))
         self.palette.to_image(image)
-        assert_list_equal(image.getpalette()[0:(self.palette.num_colors() * 3)],
+        self.assertListEqual(image.getpalette()[0:(self.palette.num_colors() * 3)],
                           [0, 0, 0, 40, 8, 72, 80, 88, 48,
                            248, 0, 0, 80, 56, 40, 16, 136, 136])
         del image
@@ -174,25 +175,25 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
     def test_add_colors_to_subpalette_single_color(self):
         self.palette.add_colors_to_subpalette([EbColor(r=64, g=32, b=16)])
 
-        assert_equal(self.palette[1, 0].tuple(), (64, 32, 16))
-        assert_true(self.palette[1, 0].used)
+        self.assertEqual(self.palette[1, 0].tuple(), (64, 32, 16))
+        self.assertTrue(self.palette[1, 0].used)
         for i in range(self.palette.num_subpalettes):
             for j in range(self.palette.subpalette_length):
                 if (i, j) not in [(1, 0)]:
-                    assert_false(self.palette[i, j].used)
+                    self.assertFalse(self.palette[i, j].used)
 
     def test_add_colors_to_subpalette_shared_colors(self):
         self.palette.add_colors_to_subpalette([EbColor(r=64, g=32, b=16)])
         self.palette.add_colors_to_subpalette([EbColor(r=64, g=32, b=16), EbColor(r=128, g=0, b=16)])
 
-        assert_equal(self.palette[1, 0].tuple(), (64, 32, 16))
-        assert_true(self.palette[1, 0].used)
-        assert_equal(self.palette[1, 1].tuple(), (128, 0, 16))
-        assert_true(self.palette[1, 1].used)
+        self.assertEqual(self.palette[1, 0].tuple(), (64, 32, 16))
+        self.assertTrue(self.palette[1, 0].used)
+        self.assertEqual(self.palette[1, 1].tuple(), (128, 0, 16))
+        self.assertTrue(self.palette[1, 1].used)
         for i in range(self.palette.num_subpalettes):
             for j in range(self.palette.subpalette_length):
                 if (i, j) not in [(1, 0), (1, 1)]:
-                    assert_false(self.palette[i, j].used)
+                    self.assertFalse(self.palette[i, j].used)
 
     def test_add_colors_to_subpalette_shared_colors2(self):
         self.palette.add_colors_to_subpalette([EbColor(r=64, g=32, b=16)])
@@ -202,74 +203,78 @@ class TestEbPalette(BaseTestCase, TilesetImageTestCase):
                                                EbColor(r=16, g=32, b=64),
                                                EbColor(r=32, g=32, b=32)])
 
-        assert_equal(self.palette[1, 0].tuple(), (64, 32, 16))
-        assert_true(self.palette[1, 0].used)
-        assert_equal(self.palette[1, 1].tuple(), (128, 0, 16))
-        assert_true(self.palette[1, 1].used)
-        assert_false(self.palette[1, 2].used)
+        self.assertEqual(self.palette[1, 0].tuple(), (64, 32, 16))
+        self.assertTrue(self.palette[1, 0].used)
+        self.assertEqual(self.palette[1, 1].tuple(), (128, 0, 16))
+        self.assertTrue(self.palette[1, 1].used)
+        self.assertFalse(self.palette[1, 2].used)
 
-        assert_equal(set([self.palette[0, x].tuple() for x in range(self.palette.subpalette_length)]),
+        self.assertEqual(set([self.palette[0, x].tuple() for x in range(self.palette.subpalette_length)]),
                      set([(64, 32, 16), (16, 32, 64), (32, 32, 32)]))
-        assert_equal([self.palette[0, x].used for x in range(self.palette.subpalette_length)].count(True), 3)
+        self.assertEqual([self.palette[0, x].used for x in range(self.palette.subpalette_length)].count(True), 3)
 
 
 class TestCreateEbPaletteFromImage(BaseTestCase, TilesetImageTestCase):
+    @skip("Forcibly disabled for some reason")
     def test_8x8_2colors_1subpaletteof2(self):
         return
         eb_palette = EbPalette(num_subpalettes=1, subpalette_length=2)
         setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_img, 8, 8)
-        assert_equal(eb_palette.num_subpalettes, 1)
-        assert_equal(eb_palette.subpalette_length, 2)
-        assert_equal(eb_palette[0, 0].tuple(), (0xf8, 0xf8, 0xf8))
-        assert_equal(eb_palette[0, 1].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette.num_subpalettes, 1)
+        self.assertEqual(eb_palette.subpalette_length, 2)
+        self.assertEqual(eb_palette[0, 0].tuple(), (0xf8, 0xf8, 0xf8))
+        self.assertEqual(eb_palette[0, 1].tuple(), (0, 0, 0))
 
+    @skip("Forcibly disabled for some reason")
     def test_extra_colors(self):
         return
         eb_palette = EbPalette(num_subpalettes=3, subpalette_length=4)
         setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_img, 8, 8)
-        assert_equal(eb_palette.num_subpalettes, 3)
-        assert_equal(eb_palette.subpalette_length, 4)
-        assert_equal(eb_palette[0, 0].tuple(), (0xf8, 0xf8, 0xf8))
-        assert_equal(eb_palette[0, 1].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[0, 2].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[0, 3].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[1, 0].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[1, 1].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[1, 2].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[1, 3].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[2, 0].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[2, 1].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[2, 2].tuple(), (0, 0, 0))
-        assert_equal(eb_palette[2, 3].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette.num_subpalettes, 3)
+        self.assertEqual(eb_palette.subpalette_length, 4)
+        self.assertEqual(eb_palette[0, 0].tuple(), (0xf8, 0xf8, 0xf8))
+        self.assertEqual(eb_palette[0, 1].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[0, 2].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[0, 3].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[1, 0].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[1, 1].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[1, 2].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[1, 3].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[2, 0].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[2, 1].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[2, 2].tuple(), (0, 0, 0))
+        self.assertEqual(eb_palette[2, 3].tuple(), (0, 0, 0))
 
+    @skip("Forcibly disabled for some reason")
     def test_8x8_5colors_2subpalettesof4(self):
         return
         eb_palette = EbPalette(num_subpalettes=2, subpalette_length=4)
         setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_3_img, 8, 8)
-        assert_equal(eb_palette.num_subpalettes, 2)
-        assert_equal(eb_palette.subpalette_length, 4)
+        self.assertEqual(eb_palette.num_subpalettes, 2)
+        self.assertEqual(eb_palette.subpalette_length, 4)
 
-        assert_set_equal({eb_palette[1, i] for i in range(4)},
+        self.assertSetEqual({eb_palette[1, i] for i in range(4)},
                          {EbColor(24, 0, 248), EbColor(0, 248, 24), EbColor(152, 0, 248), EbColor(248, 144, 0)})
-        assert_set_equal({eb_palette[0, i] for i in range(4)},
+        self.assertSetEqual({eb_palette[0, i] for i in range(4)},
                          {EbColor(24, 0, 248), EbColor(0, 248, 24), EbColor(216, 248, 0), EbColor(152, 0, 248)})
 
 
-    @raises(InvalidArgumentError)
     def test_cant_fit_colors(self):
         eb_palette = EbPalette(num_subpalettes=2, subpalette_length=1)
-        setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_img, 8, 8)
+        with self.assertRaises(InvalidArgumentError):
+            setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_img, 8, 8)
 
-    @raises(InvalidArgumentError)
     def test_cant_fit_colors_2(self):
         eb_palette = EbPalette(num_subpalettes=1, subpalette_length=4)
-        setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_3_img, 8, 8)
+        with self.assertRaises(InvalidArgumentError):
+            setup_eb_palette_from_image(eb_palette, self.tile_8x8_2bpp_3_img, 8, 8)
 
 
-def test_join_sets():
-    print("Blah")
-    result = join_sets([set([1, 2, 3]), set([3, 4, 5]), set([2, 6])], 2, 4)
-    assert_list_equal(result, [set([1, 2, 3, 6]), set([3, 4, 5])])
+class JoinSetsTestCase(BaseTestCase):
+    def test_join_sets(self):
+        # print("Blah")
+        result = join_sets([set([1, 2, 3]), set([3, 4, 5]), set([2, 6])], 2, 4)
+        self.assertListEqual(result, [set([1, 2, 3, 6]), set([3, 4, 5])])
 
-    result = join_sets([set([1, 2])], 3, 4)
-    assert_list_equal(result, [set([1, 2])])
+        result = join_sets([set([1, 2])], 3, 4)
+        self.assertListEqual(result, [set([1, 2])])

--- a/tests/model/eb/test_pointers.py
+++ b/tests/model/eb/test_pointers.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equal, raises, assert_list_equal, assert_raises
-
 from coilsnake.model.common.blocks import Block
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError, MissingUserDataError, InvalidUserDataError
 from coilsnake.model.eb.pointers import EbPointer, EbTextPointer
@@ -8,28 +6,28 @@ from tests.coilsnake_test import BaseTestCase
 
 
 class TestEbPointer(BaseTestCase):
-    def setup(self):
+    def setUp(self):
         self.pointer = EbPointer()
         EbPointer.label_address_map["a.b"] = 0x1314ab
 
-    @raises(InvalidArgumentError)
     def test_zero_size(self):
-        EbPointer(size=0)
+        with self.assertRaises(InvalidArgumentError):
+            EbPointer(size=0)
 
-    @raises(InvalidArgumentError)
     def test_negative_size(self):
-        EbPointer(size=-1)
+        with self.assertRaises(InvalidArgumentError):
+            EbPointer(size=-1)
 
     def test_from_block(self):
         block = Block()
         block.from_list(list(range(0, 0x100)))
 
         self.pointer.from_block(block, 0)
-        assert_equal(self.pointer.address, 0x020100)
+        self.assertEqual(self.pointer.address, 0x020100)
         self.pointer.from_block(block, 5)
-        assert_equal(self.pointer.address, 0x070605)
+        self.assertEqual(self.pointer.address, 0x070605)
         self.pointer.from_block(block, 0xfd)
-        assert_equal(self.pointer.address, 0xfffefd)
+        self.assertEqual(self.pointer.address, 0xfffefd)
 
     def test_to_block(self):
         block = Block()
@@ -37,27 +35,27 @@ class TestEbPointer(BaseTestCase):
 
         self.pointer.address = 0xabcdef
         self.pointer.to_block(block, 1)
-        assert_list_equal(block[0:5].to_list(), [1, 0xef, 0xcd, 0xab, 5])
+        self.assertListEqual(block[0:5].to_list(), [1, 0xef, 0xcd, 0xab, 5])
 
     def test_from_yml_rep(self):
         self.pointer.from_yml_rep("$123456")
-        assert_equal(self.pointer.address, 0x123456)
+        self.assertEqual(self.pointer.address, 0x123456)
         self.pointer.from_yml_rep("a.b")
-        assert_equal(self.pointer.address, 0x1314ab)
+        self.assertEqual(self.pointer.address, 0x1314ab)
 
-        assert_raises(MissingUserDataError, self.pointer.from_yml_rep, None)
-        assert_raises(InvalidUserDataError, self.pointer.from_yml_rep, "")
-        assert_raises(InvalidUserDataError, self.pointer.from_yml_rep, "$")
-        assert_raises(InvalidUserDataError, self.pointer.from_yml_rep, "not.real_label")
-        assert_raises(InvalidUserDataError, self.pointer.from_yml_rep, True)
+        self.assertRaises(MissingUserDataError, self.pointer.from_yml_rep, None)
+        self.assertRaises(InvalidUserDataError, self.pointer.from_yml_rep, "")
+        self.assertRaises(InvalidUserDataError, self.pointer.from_yml_rep, "$")
+        self.assertRaises(InvalidUserDataError, self.pointer.from_yml_rep, "not.real_label")
+        self.assertRaises(InvalidUserDataError, self.pointer.from_yml_rep, True)
 
     def test_yml_rep(self):
         self.pointer.address = 0xfe4392
-        assert_equal(self.pointer.yml_rep(), "$fe4392")
+        self.assertEqual(self.pointer.yml_rep(), "$fe4392")
 
 
 class TestEbTextPointer(BaseTestCase):
-    def setup(self):
+    def setUp(self):
         self.pointer = EbTextPointer(size=4)
 
     def test_from_block(self):
@@ -68,16 +66,16 @@ class TestEbTextPointer(BaseTestCase):
                          0x01, 0x02, 0x03, 0x01])
 
         self.pointer.from_block(block, 0)
-        assert_equal(self.pointer.address, 0xc2c1c0)
+        self.assertEqual(self.pointer.address, 0xc2c1c0)
         self.pointer.from_block(block, 4)
-        assert_equal(self.pointer.address, 0xffffff)
+        self.assertEqual(self.pointer.address, 0xffffff)
 
-        assert_raises(InvalidEbTextPointerError, self.pointer.from_block, block, 8)
-        assert_raises(InvalidEbTextPointerError, self.pointer.from_block, block, 12)
+        self.assertRaises(InvalidEbTextPointerError, self.pointer.from_block, block, 8)
+        self.assertRaises(InvalidEbTextPointerError, self.pointer.from_block, block, 12)
 
     def test_from_yml_rep(self):
         self.pointer.from_yml_rep("$c30201")
-        assert_equal(self.pointer.address, 0xc30201)
+        self.assertEqual(self.pointer.address, 0xc30201)
 
-        assert_raises(InvalidEbTextPointerError, self.pointer.from_yml_rep, "$070102")
-        assert_raises(InvalidEbTextPointerError, self.pointer.from_yml_rep, "$1000000")
+        self.assertRaises(InvalidEbTextPointerError, self.pointer.from_yml_rep, "$070102")
+        self.assertRaises(InvalidEbTextPointerError, self.pointer.from_yml_rep, "$1000000")

--- a/tests/model/eb/test_sprites.py
+++ b/tests/model/eb/test_sprites.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equal, assert_not_equal, assert_not_in, assert_false
-
 from coilsnake.model.eb.sprites import SpriteGroup
 from tests.coilsnake_test import SpriteGroupTestCase
 
@@ -17,39 +15,39 @@ class TestEbSpriteGroup(SpriteGroupTestCase):
 
         # Two unused sprites which are identical
         sprite_4_hash, sprite_4_flip = unique_sprite_usages[4]
-        assert_false(sprite_4_flip)
-        assert_equal(unique_sprite_usages[5], (sprite_4_hash, sprite_4_flip))
+        self.assertFalse(sprite_4_flip)
+        self.assertEqual(unique_sprite_usages[5], (sprite_4_hash, sprite_4_flip))
 
         # Two used sprites which are identical
-        assert_equal(unique_sprite_usages[0], (sprite_4_hash, sprite_4_flip))
-        assert_equal(unique_sprite_usages[1], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[0], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[1], (sprite_4_hash, sprite_4_flip))
 
         # Two used-as-flipped sprites which are identical
-        assert_equal(unique_sprite_usages[6], (sprite_4_hash, not sprite_4_flip))
-        assert_equal(unique_sprite_usages[7], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[6], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[7], (sprite_4_hash, not sprite_4_flip))
 
         # Two mirrored sprites, the first of which is used
-        assert_equal(unique_sprite_usages[2], (sprite_4_hash, sprite_4_flip))
-        assert_equal(unique_sprite_usages[3], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[2], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[3], (sprite_4_hash, not sprite_4_flip))
 
         # Two mirrored sprites, the second of which is used
-        assert_equal(unique_sprite_usages[14], (sprite_4_hash, not sprite_4_flip))
-        assert_equal(unique_sprite_usages[15], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[14], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[15], (sprite_4_hash, sprite_4_flip))
 
         # Two mirrored sprites, neither of which are used
         sprite_12_hash, sprite_12_flip = unique_sprite_usages[12]
-        assert_not_equal(sprite_4_hash, sprite_12_hash)
-        assert_equal(unique_sprite_usages[13], (sprite_12_hash, not sprite_12_flip))
+        self.assertNotEqual(sprite_4_hash, sprite_12_hash)
+        self.assertEqual(unique_sprite_usages[13], (sprite_12_hash, not sprite_12_flip))
 
         # Two sprites, both of which are used
-        assert_equal(unique_sprite_usages[10], (sprite_4_hash, sprite_4_flip))
-        assert_equal(unique_sprite_usages[11], (sprite_12_hash, sprite_12_flip))
-        assert_equal(unique_sprite_usages[10][1], unique_sprite_usages[11][1])
+        self.assertEqual(unique_sprite_usages[10], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[11], (sprite_12_hash, sprite_12_flip))
+        self.assertEqual(unique_sprite_usages[10][1], unique_sprite_usages[11][1])
 
         # Two flipped sprites, both of which are used
-        assert_equal(unique_sprite_usages[8], (sprite_4_hash, not sprite_4_flip))
-        assert_equal(unique_sprite_usages[9], (sprite_12_hash, not sprite_12_flip))
-        assert_equal(unique_sprite_usages[8][1], unique_sprite_usages[9][1])
+        self.assertEqual(unique_sprite_usages[8], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[9], (sprite_12_hash, not sprite_12_flip))
+        self.assertEqual(unique_sprite_usages[8][1], unique_sprite_usages[9][1])
 
     def test_calculate_unique_sprites_2(self):
         sg = SpriteGroup(16)
@@ -61,44 +59,44 @@ class TestEbSpriteGroup(SpriteGroupTestCase):
 
         # Two unused sprites which are identical
         sprite_4_hash, sprite_4_flip = unique_sprite_usages[4]
-        assert_equal(unique_sprite_usages[5], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[5], (sprite_4_hash, sprite_4_flip))
         hashes[sprite_4_hash] = True
 
         # One used sprite and one unused sprite
-        assert_equal(unique_sprite_usages[0], (sprite_4_hash, sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[0], (sprite_4_hash, sprite_4_flip))
         sprite_1_hash, sprite_1_flip = unique_sprite_usages[1]
-        assert_not_equal(sprite_4_hash, sprite_1_hash)
+        self.assertNotEqual(sprite_4_hash, sprite_1_hash)
         hashes[sprite_1_hash] = True
 
         # One used-as-flipped sprite and one unused sprite
-        assert_equal(unique_sprite_usages[6], (sprite_4_hash, not sprite_4_flip))
+        self.assertEqual(unique_sprite_usages[6], (sprite_4_hash, not sprite_4_flip))
         sprite_7_hash, sprite_7_flip = unique_sprite_usages[7]
-        assert_not_in(sprite_7_hash, hashes)
-        assert_equal(not sprite_4_flip, sprite_7_flip)
+        self.assertNotIn(sprite_7_hash, hashes)
+        self.assertEqual(not sprite_4_flip, sprite_7_flip)
         hashes[sprite_7_hash] = True
 
         # One unused sprite and one used sprite
         sprite_2_hash, sprite_2_flip = unique_sprite_usages[2]
-        assert_not_in(sprite_2_hash, hashes)
-        assert_equal(unique_sprite_usages[3], unique_sprite_usages[4])
+        self.assertNotIn(sprite_2_hash, hashes)
+        self.assertEqual(unique_sprite_usages[3], unique_sprite_usages[4])
         hashes[sprite_2_hash] = True
 
         # One unused sprite and one used-as-flipped sprite
         sprite_14_hash, sprite_14_flip = unique_sprite_usages[14]
-        assert_not_in(sprite_14_hash, hashes)
-        assert_equal(unique_sprite_usages[15], (sprite_4_hash, not sprite_4_flip))
+        self.assertNotIn(sprite_14_hash, hashes)
+        self.assertEqual(unique_sprite_usages[15], (sprite_4_hash, not sprite_4_flip))
         hashes[sprite_14_hash] = True
 
         # Two unused sprites
         sprite_12_hash, sprite_12_flip = unique_sprite_usages[12]
-        assert_not_in(sprite_12_hash, hashes)
+        self.assertNotIn(sprite_12_hash, hashes)
         sprite_13_hash, sprite_13_flip = unique_sprite_usages[13]
-        assert_not_equal(sprite_12_hash, sprite_13_hash)
-        assert_not_in(sprite_13_hash, hashes)
-        assert_equal(sprite_12_flip, sprite_13_flip)
+        self.assertNotEqual(sprite_12_hash, sprite_13_hash)
+        self.assertNotIn(sprite_13_hash, hashes)
+        self.assertEqual(sprite_12_flip, sprite_13_flip)
         hashes[sprite_12_hash] = True
         hashes[sprite_13_hash] = True
 
         # One unused sprite
         sprite_10_hash, sprite_10_flip = unique_sprite_usages[10]
-        assert_not_in(sprite_10_hash, hashes)
+        self.assertNotIn(sprite_10_hash, hashes)

--- a/tests/model/eb/test_swirls.py
+++ b/tests/model/eb/test_swirls.py
@@ -1,5 +1,3 @@
-from nose.tools import assert_equal, assert_list_equal
-
 from coilsnake.model.common.blocks import Block
 from coilsnake.model.eb.swirls import SwirlFrameRow, SwirlFrame
 from tests.coilsnake_test import SwirlTestCase
@@ -11,19 +9,19 @@ class TestSwirlFrameRow(SwirlTestCase):
         s = SwirlFrameRow()
 
         s.from_image_data(image_data=image_data, y=0)
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=0xff, x4=0), s)
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=0xff, x4=0), s)
 
         s.from_image_data(image_data=image_data, y=1)
-        assert_equal(SwirlFrameRow(x1=0xfe, x2=0xff, x3=0xff, x4=0), s)
+        self.assertEqual(SwirlFrameRow(x1=0xfe, x2=0xff, x3=0xff, x4=0), s)
 
         s.from_image_data(image_data=image_data, y=2)
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=0xfe, x4=0xff), s)
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=0xfe, x4=0xff), s)
 
         s.from_image_data(image_data=image_data, y=3)
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=3, x4=4), s)
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=3, x4=4), s)
 
         s.from_image_data(image_data=image_data, y=4)
-        assert_equal(SwirlFrameRow(x1=0xff, x2=0, x3=0xff, x4=0), s)
+        self.assertEqual(SwirlFrameRow(x1=0xff, x2=0, x3=0xff, x4=0), s)
 
     def test_from_block(self):
         block = Block()
@@ -31,10 +29,10 @@ class TestSwirlFrameRow(SwirlTestCase):
         s = SwirlFrameRow()
 
         s.from_block(block, 0, False)
-        assert_equal(SwirlFrameRow(x1=1, x2=2, x3=4, x4=5), s)
+        self.assertEqual(SwirlFrameRow(x1=1, x2=2, x3=4, x4=5), s)
 
         s.from_block(block, 3, True)
-        assert_equal(SwirlFrameRow(x1=5, x2=6, x3=0xff, x4=0), s)
+        self.assertEqual(SwirlFrameRow(x1=5, x2=6, x3=0xff, x4=0), s)
 
     def test_to_block(self):
         block = Block()
@@ -42,12 +40,12 @@ class TestSwirlFrameRow(SwirlTestCase):
         s = SwirlFrameRow(x1=3, x2=5, x3=55, x4=92)
         block.from_list([33, 33, 33, 33, 33])
         s.to_block(block, 1, False)
-        assert_equal([33, 3, 5, 55, 92], block.to_list())
+        self.assertEqual([33, 3, 5, 55, 92], block.to_list())
 
         s = SwirlFrameRow(x1=3, x2=5, x3=0xff, x4=0)
         block.from_list([33, 33, 33, 33, 33])
         s.to_block(block, 2, True)
-        assert_equal([33, 33, 3, 5, 33], block.to_list())
+        self.assertEqual([33, 33, 3, 5, 33], block.to_list())
 
 
 class TestSwirlFrame(SwirlTestCase):
@@ -55,11 +53,11 @@ class TestSwirlFrame(SwirlTestCase):
         s = SwirlFrame()
         s.from_image(self.swirl_1_img)
 
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=0xff, x4=0), s.rows[0])
-        assert_equal(SwirlFrameRow(x1=0xfe, x2=0xff, x3=0xff, x4=0), s.rows[1])
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=0xfe, x4=0xff), s.rows[2])
-        assert_equal(SwirlFrameRow(x1=0, x2=1, x3=3, x4=4), s.rows[3])
-        assert_equal(SwirlFrameRow(x1=0xff, x2=0, x3=0xff, x4=0), s.rows[4])
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=0xff, x4=0), s.rows[0])
+        self.assertEqual(SwirlFrameRow(x1=0xfe, x2=0xff, x3=0xff, x4=0), s.rows[1])
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=0xfe, x4=0xff), s.rows[2])
+        self.assertEqual(SwirlFrameRow(x1=0, x2=1, x3=3, x4=4), s.rows[3])
+        self.assertEqual(SwirlFrameRow(x1=0xff, x2=0, x3=0xff, x4=0), s.rows[4])
 
     def test_from_block_repeating_mode_01(self):
         s = SwirlFrame()
@@ -70,11 +68,11 @@ class TestSwirlFrame(SwirlTestCase):
                          0])
         s.from_block(block, 0)
 
-        assert_equal(len(s.rows), 224)
+        self.assertEqual(len(s.rows), 224)
         for row in s.rows[0:0x7f]:
-            assert_equal(SwirlFrameRow(x1=1, x2=2, x3=0xff, x4=0), row)
+            self.assertEqual(SwirlFrameRow(x1=1, x2=2, x3=0xff, x4=0), row)
         for row in s.rows[0x7f:]:
-            assert_equal(SwirlFrameRow(x1=3, x2=4, x3=0xff, x4=0), row)
+            self.assertEqual(SwirlFrameRow(x1=3, x2=4, x3=0xff, x4=0), row)
 
     def test_from_block_repeating_not_mode_01(self):
         s = SwirlFrame()
@@ -85,11 +83,11 @@ class TestSwirlFrame(SwirlTestCase):
                          0])
         s.from_block(block, 0)
 
-        assert_equal(len(s.rows), 224)
+        self.assertEqual(len(s.rows), 224)
         for row in s.rows[0:0x7e]:
-            assert_equal(SwirlFrameRow(x1=0, x2=50, x3=120, x4=126), row)
+            self.assertEqual(SwirlFrameRow(x1=0, x2=50, x3=120, x4=126), row)
         for row in s.rows[0x7e:]:
-            assert_equal(SwirlFrameRow(x1=0, x2=0xff, x3=0xff, x4=0), row)
+            self.assertEqual(SwirlFrameRow(x1=0, x2=0xff, x3=0xff, x4=0), row)
 
     def test_from_block_continuous_mode_01(self):
         s = SwirlFrame()
@@ -101,13 +99,13 @@ class TestSwirlFrame(SwirlTestCase):
                          0])
         s.from_block(block, 0)
 
-        assert_equal(len(s.rows), 224)
+        self.assertEqual(len(s.rows), 224)
         for row in s.rows[0:0x7f]:
-            assert_equal(SwirlFrameRow(x1=1, x2=2, x3=0xff, x4=0), row)
-        assert_equal(SwirlFrameRow(x1=50, x2=51, x3=0xff, x4=0), s.rows[0x7f])
-        assert_equal(SwirlFrameRow(x1=52, x2=53, x3=0xff, x4=0), s.rows[0x80])
+            self.assertEqual(SwirlFrameRow(x1=1, x2=2, x3=0xff, x4=0), row)
+        self.assertEqual(SwirlFrameRow(x1=50, x2=51, x3=0xff, x4=0), s.rows[0x7f])
+        self.assertEqual(SwirlFrameRow(x1=52, x2=53, x3=0xff, x4=0), s.rows[0x80])
         for row in s.rows[0x81:]:
-            assert_equal(SwirlFrameRow(x1=3, x2=4, x3=0xff, x4=0), row)
+            self.assertEqual(SwirlFrameRow(x1=3, x2=4, x3=0xff, x4=0), row)
 
     def test_from_block_continuous_not_mode_01(self):
         s = SwirlFrame()
@@ -119,20 +117,20 @@ class TestSwirlFrame(SwirlTestCase):
                          0])
         s.from_block(block, 0)
 
-        assert_equal(len(s.rows), 224)
+        self.assertEqual(len(s.rows), 224)
         for row in s.rows[0:0x7f]:
-            assert_equal(SwirlFrameRow(x1=0, x2=50, x3=120, x4=126), row)
-        assert_equal(SwirlFrameRow(x1=50, x2=51, x3=52, x4=53), s.rows[0x7f])
-        assert_equal(SwirlFrameRow(x1=54, x2=55, x3=0xff, x4=0), s.rows[0x80])
+            self.assertEqual(SwirlFrameRow(x1=0, x2=50, x3=120, x4=126), row)
+        self.assertEqual(SwirlFrameRow(x1=50, x2=51, x3=52, x4=53), s.rows[0x7f])
+        self.assertEqual(SwirlFrameRow(x1=54, x2=55, x3=0xff, x4=0), s.rows[0x80])
         for row in s.rows[0x81:]:
-            assert_equal(SwirlFrameRow(x1=0, x2=0xff, x3=0xff, x4=0), row)
+            self.assertEqual(SwirlFrameRow(x1=0, x2=0xff, x3=0xff, x4=0), row)
 
     def test_block_rep_repeating_mode_01(self):
         s = SwirlFrame()
         for row in s.rows:
             row.set(1, 2, 0xff, 0)
 
-        assert_list_equal([1,
+        self.assertListEqual([1,
                            0x7f, 1, 2,
                            97, 1, 2,
                            0],
@@ -143,7 +141,7 @@ class TestSwirlFrame(SwirlTestCase):
         for row in s.rows:
             row.set(1, 2, 3, 4)
 
-        assert_list_equal([4,
+        self.assertListEqual([4,
                            0x7f, 1, 2, 3, 4,
                            97, 1, 2, 3, 4,
                            0],
@@ -155,7 +153,7 @@ class TestSwirlFrame(SwirlTestCase):
             row.set(1, 2, 0xff, 0)
         s.rows[55].set(5, 6, 0xff, 0)
 
-        assert_list_equal([1,
+        self.assertListEqual([1,
                            55, 1, 2,
                            0x81, 5, 6,
                            0x7f, 1, 2,
@@ -169,7 +167,7 @@ class TestSwirlFrame(SwirlTestCase):
             row.set(1, 2, 0xff, 0)
         s.rows[55].set(5, 6, 7, 8)
 
-        assert_list_equal([4,
+        self.assertListEqual([4,
                            55, 1, 2, 0xff, 0,
                            0x81, 5, 6, 7, 8,
                            0x7f, 1, 2, 0xff, 0,
@@ -182,7 +180,7 @@ class TestSwirlFrame(SwirlTestCase):
         for i, row in enumerate(s.rows):
             row.set(i, i+1, 0xff, 0)
 
-        assert_list_equal([1,
+        self.assertListEqual([1,
 
                            0xff, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13,
                            13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22, 23, 23, 24, 24,

--- a/tests/modules/eb/test_CccInterfaceModule.py
+++ b/tests/modules/eb/test_CccInterfaceModule.py
@@ -1,8 +1,7 @@
 import os
 import os.path
 
-import mock
-from nose.tools import assert_equal, assert_true, assert_dict_equal, assert_false, assert_is_none
+import unittest.mock as mock
 
 from coilsnake.model.eb.pointers import EbPointer
 from coilsnake.modules.eb import CccInterfaceModule
@@ -11,13 +10,13 @@ from tests.coilsnake_test import BaseTestCase, TemporaryWritableFileTestCase, TE
 
 
 class TestCccInterfaceModule(BaseTestCase, TemporaryWritableFileTestCase):
-    def setup(self):
-        super(TestCccInterfaceModule, self).setup()
+    def setUp(self):
+        super(TestCccInterfaceModule, self).setUp()
         self.mock = mock.Mock()
         self.module = CccInterfaceModule.CccInterfaceModule()
 
-    def teardown(self):
-        super(TestCccInterfaceModule, self).teardown()
+    def tearDown(self):
+        super(TestCccInterfaceModule, self).tearDown()
         del self.mock
         del self.module
 
@@ -27,8 +26,8 @@ class TestCccInterfaceModule(BaseTestCase, TemporaryWritableFileTestCase):
 
         self.module.write_to_project(resource_open)
 
-        assert_true(os.path.isfile(self.temporary_wo_file_name))
-        assert_equal(0, os.path.getsize(self.temporary_wo_file_name))
+        self.assertTrue(os.path.isfile(self.temporary_wo_file_name))
+        self.assertEqual(0, os.path.getsize(self.temporary_wo_file_name))
 
     def test_read_from_project(self):
         with open(os.path.join(TEST_DATA_DIR, 'summary.txt'), 'r') as summary_file:
@@ -37,8 +36,8 @@ class TestCccInterfaceModule(BaseTestCase, TemporaryWritableFileTestCase):
 
             self.module.read_from_project(resource_open)
 
-        assert_equal((from_snes_address(0xf10000), from_snes_address(0xf19430)), self.module.used_range)
-        assert_dict_equal(
+        self.assertEqual((from_snes_address(0xf10000), from_snes_address(0xf19430)), self.module.used_range)
+        self.assertDictEqual(
             {
                 'file1.test1': 0xc23456,
                 'file1.test2': 0xf18cfb,
@@ -59,8 +58,8 @@ class TestCccInterfaceModule(BaseTestCase, TemporaryWritableFileTestCase):
 
             self.module.read_from_project(resource_open)
 
-        assert_is_none(self.module.used_range)
-        assert_false(EbPointer.label_address_map)
+        self.assertIsNone(self.module.used_range)
+        self.assertFalse(EbPointer.label_address_map)
 
     def test_read_from_project_blank_summary(self):
         with open(os.path.join(TEST_DATA_DIR, 'summary_blank.txt'), 'r') as summary_file:
@@ -69,12 +68,12 @@ class TestCccInterfaceModule(BaseTestCase, TemporaryWritableFileTestCase):
 
             self.module.read_from_project(resource_open)
 
-        assert_is_none(self.module.used_range)
-        assert_false(EbPointer.label_address_map)
+        self.assertIsNone(self.module.used_range)
+        self.assertFalse(EbPointer.label_address_map)
 
     def test_write_to_rom(self):
         self.module.write_to_rom(self.mock)
-        assert_false(self.mock.mark_allocated.called)
+        self.assertFalse(self.mock.mark_allocated.called)
 
         self.module.used_range = (0x312345, 0x345678)
         self.module.write_to_rom(self.mock)

--- a/tests/modules/eb/test_DoorModule.py
+++ b/tests/modules/eb/test_DoorModule.py
@@ -1,28 +1,26 @@
 import os
 
-from nose.tools import assert_equal, assert_true, assert_dict_equal
-from nose.tools.nontrivial import nottest
+from unittest import skipUnless
 
 from coilsnake.modules.eb.DoorModule import DoorModule
 from coilsnake.model.common.blocks import Rom
-from tests.coilsnake_test import BaseTestCase, TemporaryWritableFileTestCase, TEST_DATA_DIR
+from tests.coilsnake_test import BaseTestCase, TemporaryWritableFileTestCase, TEST_DATA_DIR, earthbound_rom_available
 
 
 class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
-    def setup(self):
-        super(TestDoorModule, self).setup()
+    def setUp(self):
+        super(TestDoorModule, self).setUp()
         self.module = DoorModule()
 
-    def teardown(self):
-        super(TestDoorModule, self).teardown()
+    def tearDown(self):
+        super(TestDoorModule, self).tearDown()
         del self.module
 
-    @nottest
-    def test_read_from_rom_using_rom(self, rom):
+    def impl_test_read_from_rom_using_rom(self, rom):
         self.module.read_from_rom(rom)
 
         # Very simple verification by checking the amount of different types of doors that were read
-        assert_equal(len(self.module.door_areas), 40 * 32)
+        self.assertEqual(len(self.module.door_areas), 40 * 32)
         num_door_types = dict()
         num_empty_areas = 0
         for area in self.module.door_areas:
@@ -34,8 +32,8 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
                         num_door_types[door.__class__.__name__] += 1
             else:
                 num_empty_areas += 1
-        assert_equal(num_empty_areas, 679)
-        assert_dict_equal(num_door_types, {
+        self.assertEqual(num_empty_areas, 679)
+        self.assertDictEqual(num_door_types, {
             "SwitchDoor": 6,
             "EscalatorOrStairwayDoor": 92,
             "Door": 1072,
@@ -43,13 +41,13 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
             "RopeOrLadderDoor": 641,
         })
 
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
     def test_read_from_rom(self):
         with Rom() as rom:
             rom.from_file(os.path.join(TEST_DATA_DIR, 'roms', 'real_EarthBound.smc'))
-            self.test_read_from_rom_using_rom(rom)
+            self.impl_test_read_from_rom_using_rom(rom)
 
-    @nottest
-    def test_read_from_project_using_filename(self, filename):
+    def impl_test_read_from_rom_using_filename(self, filename):
         with open(filename, 'r', encoding="utf-8") as doors_file:
             def resource_open(a, b, astext):
                 return doors_file
@@ -57,7 +55,7 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
             self.module.read_from_project(resource_open)
 
         # Very simple verification by checking the amount of different types of doors that were read
-        assert_equal(len(self.module.door_areas), 40 * 32)
+        self.assertEqual(len(self.module.door_areas), 40 * 32)
         num_door_types = dict()
         num_empty_areas = 0
         for area in self.module.door_areas:
@@ -69,8 +67,8 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
                         num_door_types[door.__class__.__name__] += 1
             else:
                 num_empty_areas += 1
-        assert_equal(num_empty_areas, 679)
-        assert_dict_equal(num_door_types, {
+        self.assertEqual(num_empty_areas, 679)
+        self.assertDictEqual(num_door_types, {
             "SwitchDoor": 6,
             "EscalatorOrStairwayDoor": 92,
             "Door": 1072,
@@ -78,6 +76,7 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
             "RopeOrLadderDoor": 641,
         })
 
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
     def test_write_to_project(self):
         with Rom() as rom:
             rom.from_file(os.path.join(TEST_DATA_DIR, 'roms', 'real_EarthBound.smc'))
@@ -88,10 +87,11 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
 
         self.module.write_to_project(resource_open)
 
-        assert_true(os.path.isfile(self.temporary_wo_file_name))
+        self.assertTrue(os.path.isfile(self.temporary_wo_file_name))
         self.temporary_wo_file.close()
-        self.test_read_from_project_using_filename(self.temporary_wo_file_name)
+        self.impl_test_read_from_rom_using_filename(self.temporary_wo_file_name)
 
+    @skipUnless(earthbound_rom_available(), "real_EarthBound.smc is missing")
     def test_write_to_rom(self):
         with Rom() as rom:
             rom.from_file(os.path.join(TEST_DATA_DIR, 'roms', 'real_EarthBound.smc'))
@@ -108,4 +108,4 @@ class TestDoorModule(BaseTestCase, TemporaryWritableFileTestCase):
         with Rom() as rom:
             rom.from_file(os.path.join(TEST_DATA_DIR, 'roms', 'real_EarthBound.smc'))
             self.module.write_to_rom(rom)
-            self.test_read_from_rom_using_rom(rom)
+            self.impl_test_read_from_rom_using_rom(rom)

--- a/tests/modules/eb/test_EbModule.py
+++ b/tests/modules/eb/test_EbModule.py
@@ -2,13 +2,12 @@ import array
 import os
 from zlib import crc32
 
-from nose.tools import nottest
-from nose.tools import assert_equal
+from unittest import skip
 
 from coilsnake.modules.eb import EbModule
 from coilsnake.model.common.blocks import Rom
 from coilsnake.util.eb import native_comp
-from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR
+from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR, earthbound_rom_available
 
 
 class TestEbModule(BaseTestCase):
@@ -16,55 +15,55 @@ class TestEbModule(BaseTestCase):
     A test class for the EbModule module
     """
 
-    def setup(self):
+    def setUp(self):
         self.rom = Rom()
         self.rom.from_file(os.path.join(TEST_DATA_DIR, "roms", "EB_fake_24mbit.smc"))
 
-    @nottest
-    def test_decomp(self, decomp):
+    def impl_test_decomp(self, decomp):
+        if not earthbound_rom_available():
+            self.skipTest("real_EarthBound.smc is missing")
         onett_map = array.array('B')
         with Rom() as eb_rom:
             eb_rom.from_file(os.path.join(TEST_DATA_DIR, "roms", "real_EarthBound.smc"))
             onett_map.fromlist(decomp(eb_rom, 0x2021a8))
 
-        assert_equal(len(onett_map), 18496)
-        assert_equal(crc32(onett_map), 739047015)
+        self.assertEqual(len(onett_map), 18496)
+        self.assertEqual(crc32(onett_map), 739047015)
 
-    @nottest
-    def test_comp(self, comp, decomp):
+    def impl_test_comp(self, comp, decomp):
         a = array.array('B')
         with open(os.path.join(TEST_DATA_DIR, "binaries", "compressible.bin"), 'rb') as f:
             a.frombytes(f.read())
-        assert_equal(len(a), 18496)
+        self.assertEqual(len(a), 18496)
 
         uncompressed_data = a.tolist()
         compressed_data = comp(uncompressed_data)
-        assert_equal(len(compressed_data), 58)
+        self.assertLessEqual(len(compressed_data), 40)
 
         with Rom() as fake_eb_rom:
             fake_eb_rom.from_file(os.path.join(TEST_DATA_DIR, "roms", "EB_fake_32mbit.smc"))
             fake_eb_rom[0x300000:0x300000 + len(compressed_data)] = compressed_data
             reuncompressed_data = decomp(fake_eb_rom, 0x300000)
 
-        assert_equal(len(reuncompressed_data), len(uncompressed_data))
-        assert_equal(reuncompressed_data, uncompressed_data)
+        self.assertEqual(len(reuncompressed_data), len(uncompressed_data))
+        self.assertEqual(reuncompressed_data, uncompressed_data)
 
-    @nottest
-    def _test_python_comp(self):
-        self.test_comp(EbModule._comp, EbModule.decomp)
+    @skip("Python compression fallback is unimplemented")
+    def test_python_comp(self):
+        self.impl_test_comp(EbModule._comp, EbModule.decomp)
 
-    @nottest
-    def _test_python_decomp(self):
-        self.test_decomp(EbModule._decomp)
+    @skip("Python compression fallback is unimplemented")
+    def test_python_decomp(self):
+        self.impl_test_decomp(EbModule._decomp)
 
     def test_native_comp(self):
-        self.test_comp(native_comp.comp, native_comp.decomp)
+        self.impl_test_comp(native_comp.comp, native_comp.decomp)
 
     def test_native_decomp(self):
-        self.test_decomp(native_comp.decomp)
+        self.impl_test_decomp(native_comp.decomp)
 
     def test_default_comp(self):
-        self.test_comp(EbModule.comp, EbModule.decomp)
+        self.impl_test_comp(EbModule.comp, EbModule.decomp)
 
     def test_default_decomp(self):
-        self.test_decomp(EbModule.decomp)
+        self.impl_test_decomp(EbModule.decomp)

--- a/tests/test_data/roms/real_EarthBound.smc.md5
+++ b/tests/test_data/roms/real_EarthBound.smc.md5
@@ -1,1 +1,1 @@
-abe493b665f7467000bcf8c373b323fd  real_EarthBound.smc
+43382cc46e616ebd7ec05a33797f8499  tests/test_data/roms/real_EarthBound.smc

--- a/tests/util/common/test_project.py
+++ b/tests/util/common/test_project.py
@@ -1,7 +1,5 @@
 import os
 
-from nose.tools import assert_equal
-
 from coilsnake.util.common import project
 from tests.coilsnake_test import BaseTestCase, TEST_DATA_DIR
 
@@ -11,44 +9,44 @@ class TestProject(BaseTestCase):
     A test class for the Project module
     """
 
-    def setup(self):
+    def setUp(self):
         self.project = project.Project()
 
     def test_empty_project(self):
-        assert_equal(self.project.romtype, "Unknown")
-        assert_equal(self.project._resources, {})
+        self.assertEqual(self.project.romtype, "Unknown")
+        self.assertEqual(self.project._resources, {})
 
     def test_load(self):
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "EB.snake"))
-        assert_equal(self.project.romtype, "Earthbound")
+        self.assertEqual(self.project.romtype, "Earthbound")
         with self.project.get_resource("eb.MapModule", "map") as f:
-            assert_equal(f.name, os.path.join(TEST_DATA_DIR, "projects", "eb.MapModule_map.dat"))
+            self.assertEqual(f.name, os.path.join(TEST_DATA_DIR, "projects", "eb.MapModule_map.dat"))
 
         with open(os.path.join(TEST_DATA_DIR, "projects", "Dummy.snake")) as f:
             self.project.load(f)
-            assert_equal(self.project.romtype, "DummyRomtype")
-            assert_equal(self.project._resources, {})
+            self.assertEqual(self.project.romtype, "DummyRomtype")
+            self.assertEqual(self.project._resources, {})
 
     def test_load_new(self):
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "dne.snake"))
-        assert_equal(self.project.romtype, "Unknown")
-        assert_equal(self.project._resources, {})
+        self.assertEqual(self.project.romtype, "Unknown")
+        self.assertEqual(self.project._resources, {})
 
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "EB.snake"))
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "dne.snake"))
-        assert_equal(self.project.romtype, "Unknown")
-        assert_equal(self.project._resources, {})
+        self.assertEqual(self.project.romtype, "Unknown")
+        self.assertEqual(self.project._resources, {})
 
     def test_load_with_romtype(self):
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "EB.snake"), "NotEarthbound")
-        assert_equal(self.project.romtype, "NotEarthbound")
-        assert_equal(self.project._resources, {})
+        self.assertEqual(self.project.romtype, "NotEarthbound")
+        self.assertEqual(self.project._resources, {})
 
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "EB.snake"), "Earthbound")
-        assert_equal(self.project.romtype, "Earthbound")
+        self.assertEqual(self.project.romtype, "Earthbound")
         with self.project.get_resource("eb.MapModule", "map") as f:
-            assert_equal(f.name, os.path.join(TEST_DATA_DIR, "projects", "eb.MapModule_map.dat"))
+            self.assertEqual(f.name, os.path.join(TEST_DATA_DIR, "projects", "eb.MapModule_map.dat"))
 
         self.project.load(os.path.join(TEST_DATA_DIR, "projects", "EB.snake"), "NotEarthbound2")
-        assert_equal(self.project.romtype, "NotEarthbound2")
-        assert_equal(self.project._resources, {})
+        self.assertEqual(self.project.romtype, "NotEarthbound2")
+        self.assertEqual(self.project._resources, {})

--- a/tests/util/common/test_yml.py
+++ b/tests/util/common/test_yml.py
@@ -1,30 +1,28 @@
 import os
 
-from nose.tools import assert_equal
-
 from coilsnake.util.common.yml import replace_field_in_yml, convert_values_to_hex_repr
-from tests.coilsnake_test import BaseTestCase, TemporaryWritableFileTestCase, TEST_DATA_DIR, assert_files_equal
+from tests.coilsnake_test import BaseTestCase, TemporaryWritableFileTestCase, TEST_DATA_DIR
 
 
 class TestReplaceFieldInYml(BaseTestCase, TemporaryWritableFileTestCase):
     def test_replace_field_in_yml(self):
         with open(os.path.join(TEST_DATA_DIR, "yml", "sample.yml"), "r") as sample_yml:
             def resource_open_r(name, extension, astext):
-                assert_equal(name, "sample_resource")
-                assert_equal(extension, "yml")
-                assert_equal(astext, True)
+                self.assertEqual(name, "sample_resource")
+                self.assertEqual(extension, "yml")
+                self.assertEqual(astext, True)
                 return open(os.path.join(TEST_DATA_DIR, "yml", "sample.yml"), encoding="utf-8", newline="\n")
 
             def resource_open_r2(name, extension, astext):
-                assert_equal(name, "sample_resource")
-                assert_equal(extension, "yml")
-                assert_equal(astext, True)
+                self.assertEqual(name, "sample_resource")
+                self.assertEqual(extension, "yml")
+                self.assertEqual(astext, True)
                 return open(self.temporary_wo_file_name, "r", encoding="utf-8", newline="\n")
 
             def resource_open_w(name, extension, astext):
-                assert_equal(name, "sample_resource")
-                assert_equal(extension, "yml")
-                assert_equal(astext, True)
+                self.assertEqual(name, "sample_resource")
+                self.assertEqual(extension, "yml")
+                self.assertEqual(astext, True)
                 return open(self.temporary_wo_file_name, "w", encoding="utf-8", newline="\n")
 
             replace_field_in_yml(resource_name="sample_resource",
@@ -46,16 +44,16 @@ class TestReplaceFieldInYml(BaseTestCase, TemporaryWritableFileTestCase):
                                  value_map={"party": "back at ya",
                                             "enemy": "at them"})
 
-            with open(self.temporary_wo_file_name, "r", encoding="utf-8", newline="\n") as f:
-                print(f.read())
+            # with open(self.temporary_wo_file_name, "r", encoding="utf-8", newline="\n") as f:
+            #     print(f.read())
 
             with open(os.path.join(TEST_DATA_DIR, "yml", "sample-replaced.yml"), "r", encoding="utf-8", newline="\n") as f1:
                 with open(self.temporary_wo_file_name, "r", encoding="utf-8", newline="\n") as f2:
-                    assert_files_equal(f1, f2)
+                    self.assert_files_equal(f1, f2)
 
-
-def test_convert_values_to_hex_repr():
-    assert_equal(convert_values_to_hex_repr("ABC: 0", "ABC"), "ABC: 0x0")
-    assert_equal(convert_values_to_hex_repr("ABC: 55", "ABC"), "ABC: 0x37")
-    assert_equal(convert_values_to_hex_repr("ABC: 55", "ABCD"), "ABC: 55")
-    assert_equal(convert_values_to_hex_repr("A:\n  - {ABC: 16}", "ABC"), "A:\n  - {ABC: 0x10}")
+class TestConvertValuesToHexRepr(BaseTestCase):
+    def test_convert_values_to_hex_repr(self):
+        self.assertEqual(convert_values_to_hex_repr("ABC: 0", "ABC"), "ABC: 0x0")
+        self.assertEqual(convert_values_to_hex_repr("ABC: 55", "ABC"), "ABC: 0x37")
+        self.assertEqual(convert_values_to_hex_repr("ABC: 55", "ABCD"), "ABC: 55")
+        self.assertEqual(convert_values_to_hex_repr("A:\n  - {ABC: 16}", "ABC"), "A:\n  - {ABC: 0x10}")

--- a/tests/util/eb/test_graphics.py
+++ b/tests/util/eb/test_graphics.py
@@ -1,440 +1,366 @@
-from nose.tools import assert_list_equal, assert_equal
-
 from coilsnake.model.common.blocks import Block
 from coilsnake.util.eb.graphics import read_1bpp_graphic_from_block, write_1bpp_graphic_to_block, \
     read_2bpp_graphic_from_block, write_2bpp_graphic_to_block, write_4bpp_graphic_to_block, read_4bpp_graphic_from_block
 
+from tests.coilsnake_test import BaseTestCase
 
-def test_read_1bpp_graphic_from_block():
-    source = Block()
-    source.from_list([42,
-                      0b00000011,
-                      0b01110000,
-                      0b01001001,
-                      0b11110000,
-                      0b01001010,
-                      0b11001000,
-                      0b01110001,
-                      0b00000001])
-    target = [[0 for x in range(8)] for y in range(8)]
-    assert_equal(8, read_1bpp_graphic_from_block(source, target, 1, x=0, y=0, height=8))
+class GraphicsTestCase(BaseTestCase):
+    def test_read_1bpp_graphic_from_block(self):
+        source = Block()
+        source.from_list([42,
+                          0b00000011,
+                          0b01110000,
+                          0b01001001,
+                          0b11110000,
+                          0b01001010,
+                          0b11001000,
+                          0b01110001,
+                          0b00000001])
+        target = [[0 for x in range(8)] for y in range(8)]
+        self.assertEqual(8, read_1bpp_graphic_from_block(source, target, 1, x=0, y=0, height=8))
 
-    assert_list_equal(target, [
-        [0, 0, 0, 0, 0, 0, 1, 1],
-        [0, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 0, 1],
-        [1, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 1, 0],
-        [1, 1, 0, 0, 1, 0, 0, 0],
-        [0, 1, 1, 1, 0, 0, 0, 1],
-        [0, 0, 0, 0, 0, 0, 0, 1]])
-
-
-def test_read_1bpp_graphic_from_block_offset_target():
-    source = Block()
-    source.from_list([0b00000011,
-                      0b01110000,
-                      0b01001001,
-                      0b11110000,
-                      0b01001010,
-                      0b11001000,
-                      0b01110001,
-                      0b00000001])
-    target = [[0 for x in range(10)] for y in range(10)]
-    assert_equal(8, read_1bpp_graphic_from_block(source, target, 0, x=2, y=1, height=8))
-
-    assert_list_equal(target, [
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-        [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-        [0, 0, 0, 1, 0, 0, 1, 0, 0, 1],
-        [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
-        [0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
-        [0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
-        [0, 0, 0, 1, 1, 1, 0, 0, 0, 1],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+        self.assertListEqual(target, [
+            [0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 0, 1],
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 1, 0],
+            [1, 1, 0, 0, 1, 0, 0, 0],
+            [0, 1, 1, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 1]])
 
 
-def test_read_1bpp_graphic_from_block_rectangular_short():
-    source = Block()
-    source.from_list([42, 0xeb,
-                      0b00000011,
-                      0b01110000,
-                      0b01001001,
-                      0b11110000,
-                      0b01001010,
-                      0b11001000])
-    target = [[0 for x in range(8)] for y in range(6)]
-    assert_equal(6, read_1bpp_graphic_from_block(source, target, 2, x=0, y=0, height=6))
+    def test_read_1bpp_graphic_from_block_offset_target(self):
+        source = Block()
+        source.from_list([0b00000011,
+                          0b01110000,
+                          0b01001001,
+                          0b11110000,
+                          0b01001010,
+                          0b11001000,
+                          0b01110001,
+                          0b00000001])
+        target = [[0 for x in range(10)] for y in range(10)]
+        self.assertEqual(8, read_1bpp_graphic_from_block(source, target, 0, x=2, y=1, height=8))
 
-    assert_list_equal(target, [
-        [0, 0, 0, 0, 0, 0, 1, 1],
-        [0, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 0, 1],
-        [1, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 1, 0],
-        [1, 1, 0, 0, 1, 0, 0, 0]])
-
-
-def test_read_1bpp_graphic_from_block_rectangular_tall():
-    source = Block()
-    source.from_list([42, 11, 99,
-                      0b00000011,
-                      0b01110000,
-                      0b01001001,
-                      0b11110000,
-                      0b01001010,
-                      0b11001000,
-                      0b01110001,
-                      0b00000001,
-                      0b00100000,
-                      0b00110000,
-                      0b00101000,
-                      0b00101000,
-                      0b01100000,
-                      0b11100000,
-                      0b11000000,
-                      0b00000001,
-                      12, 21])
-    target = [[0 for x in range(8)] for y in range(16)]
-    assert_equal(16, read_1bpp_graphic_from_block(source, target, 3, x=0, y=0, height=16))
-
-    assert_list_equal(target, [
-        [0, 0, 0, 0, 0, 0, 1, 1],
-        [0, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 0, 1],
-        [1, 1, 1, 1, 0, 0, 0, 0],
-        [0, 1, 0, 0, 1, 0, 1, 0],
-        [1, 1, 0, 0, 1, 0, 0, 0],
-        [0, 1, 1, 1, 0, 0, 0, 1],
-        [0, 0, 0, 0, 0, 0, 0, 1],
-        [0, 0, 1, 0, 0, 0, 0, 0],
-        [0, 0, 1, 1, 0, 0, 0, 0],
-        [0, 0, 1, 0, 1, 0, 0, 0],
-        [0, 0, 1, 0, 1, 0, 0, 0],
-        [0, 1, 1, 0, 0, 0, 0, 0],
-        [1, 1, 1, 0, 0, 0, 0, 0],
-        [1, 1, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 1]])
+        self.assertListEqual(target, [
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+            [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
+            [0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
+            [0, 0, 0, 1, 1, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
-def test_write_1bpp_graphic_to_block():
-    source = [[0, 0, 0, 0, 0, 0, 1, 1],
-              [0, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 0, 1],
-              [1, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 1, 0],
-              [1, 1, 0, 0, 1, 0, 0, 0],
-              [0, 1, 1, 1, 0, 0, 0, 1],
-              [0, 0, 0, 0, 0, 0, 0, 1]]
-    target = Block()
-    target.from_list([32] * 10)
-    assert_equal(8, write_1bpp_graphic_to_block(source, target, 1, x=0, y=0, height=8))
-    assert_list_equal(target.to_list(), [32,
-                                         0b00000011,
-                                         0b01110000,
-                                         0b01001001,
-                                         0b11110000,
-                                         0b01001010,
-                                         0b11001000,
-                                         0b01110001,
-                                         0b00000001,
-                                         32])
+    def test_read_1bpp_graphic_from_block_rectangular_short(self):
+        source = Block()
+        source.from_list([42, 0xeb,
+                          0b00000011,
+                          0b01110000,
+                          0b01001001,
+                          0b11110000,
+                          0b01001010,
+                          0b11001000])
+        target = [[0 for x in range(8)] for y in range(6)]
+        self.assertEqual(6, read_1bpp_graphic_from_block(source, target, 2, x=0, y=0, height=6))
+
+        self.assertListEqual(target, [
+            [0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 0, 1],
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 1, 0],
+            [1, 1, 0, 0, 1, 0, 0, 0]])
 
 
-def test_write_1bpp_graphic_to_block_offset_source():
-    source = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-              [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
-              [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-              [0, 0, 0, 1, 0, 0, 1, 0, 0, 1],
-              [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
-              [0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
-              [0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
-              [0, 0, 0, 1, 1, 1, 0, 0, 0, 1],
-              [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
-    target = Block()
-    target.from_list([0] * 8)
-    assert_equal(8, write_1bpp_graphic_to_block(source, target, 0, x=2, y=1, height=8))
-    assert_list_equal(target.to_list(), [0b00000011,
-                                         0b01110000,
-                                         0b01001001,
-                                         0b11110000,
-                                         0b01001010,
-                                         0b11001000,
-                                         0b01110001,
-                                         0b00000001])
+    def test_read_1bpp_graphic_from_block_rectangular_tall(self):
+        source = Block()
+        source.from_list([42, 11, 99,
+                          0b00000011,
+                          0b01110000,
+                          0b01001001,
+                          0b11110000,
+                          0b01001010,
+                          0b11001000,
+                          0b01110001,
+                          0b00000001,
+                          0b00100000,
+                          0b00110000,
+                          0b00101000,
+                          0b00101000,
+                          0b01100000,
+                          0b11100000,
+                          0b11000000,
+                          0b00000001,
+                          12, 21])
+        target = [[0 for x in range(8)] for y in range(16)]
+        self.assertEqual(16, read_1bpp_graphic_from_block(source, target, 3, x=0, y=0, height=16))
+
+        self.assertListEqual(target, [
+            [0, 0, 0, 0, 0, 0, 1, 1],
+            [0, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 0, 1],
+            [1, 1, 1, 1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 1, 0],
+            [1, 1, 0, 0, 1, 0, 0, 0],
+            [0, 1, 1, 1, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 0, 0, 1],
+            [0, 0, 1, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 0, 1, 0, 0, 0],
+            [0, 0, 1, 0, 1, 0, 0, 0],
+            [0, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 1]])
 
 
-def test_write_1bpp_graphic_to_block_rectangular_short():
-    source = [[0, 0, 0, 0, 0, 0, 1, 1],
-              [0, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 0, 1],
-              [1, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 1, 0],
-              [1, 1, 0, 0, 1, 0, 0, 0]]
-    target = Block()
-    target.from_list([0xeb] * 8)
-    target[0] = 42
-    assert_equal(6, write_1bpp_graphic_to_block(source, target, 2, x=0, y=0, height=6))
-    assert_list_equal(target.to_list(), [42, 0xeb,
-                                         0b00000011,
-                                         0b01110000,
-                                         0b01001001,
-                                         0b11110000,
-                                         0b01001010,
-                                         0b11001000])
+    def test_write_1bpp_graphic_to_block(self):
+        source = [[0, 0, 0, 0, 0, 0, 1, 1],
+                  [0, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 0, 1],
+                  [1, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 1, 0],
+                  [1, 1, 0, 0, 1, 0, 0, 0],
+                  [0, 1, 1, 1, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 0, 0, 0, 1]]
+        target = Block()
+        target.from_list([32] * 10)
+        self.assertEqual(8, write_1bpp_graphic_to_block(source, target, 1, x=0, y=0, height=8))
+        self.assertListEqual(target.to_list(), [32,
+                                             0b00000011,
+                                             0b01110000,
+                                             0b01001001,
+                                             0b11110000,
+                                             0b01001010,
+                                             0b11001000,
+                                             0b01110001,
+                                             0b00000001,
+                                             32])
 
 
-def test_read_1bpp_graphic_from_block_rectangular_tall():
-    source = [[0, 0, 0, 0, 0, 0, 1, 1],
-              [0, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 0, 1],
-              [1, 1, 1, 1, 0, 0, 0, 0],
-              [0, 1, 0, 0, 1, 0, 1, 0],
-              [1, 1, 0, 0, 1, 0, 0, 0],
-              [0, 1, 1, 1, 0, 0, 0, 1],
-              [0, 0, 0, 0, 0, 0, 0, 1],
-              [0, 0, 1, 0, 0, 0, 0, 0],
-              [0, 0, 1, 1, 0, 0, 0, 0],
-              [0, 0, 1, 0, 1, 0, 0, 0],
-              [0, 0, 1, 0, 1, 0, 0, 0],
-              [0, 1, 1, 0, 0, 0, 0, 0],
-              [1, 1, 1, 0, 0, 0, 0, 0],
-              [1, 1, 0, 0, 0, 0, 0, 0],
-              [0, 0, 0, 0, 0, 0, 0, 1]]
-    target = Block()
-    target.from_list([42, 11, 99, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 112, 113, 114, 115, 116, 12, 21])
-    assert_equal(16, write_1bpp_graphic_to_block(source, target, 3, x=0, y=0, height=16))
-    assert_list_equal(target.to_list(), [42, 11, 99,
-                                         0b00000011,
-                                         0b01110000,
-                                         0b01001001,
-                                         0b11110000,
-                                         0b01001010,
-                                         0b11001000,
-                                         0b01110001,
-                                         0b00000001,
-                                         0b00100000,
-                                         0b00110000,
-                                         0b00101000,
-                                         0b00101000,
-                                         0b01100000,
-                                         0b11100000,
-                                         0b11000000,
-                                         0b00000001,
-                                         12, 21])
+    def test_write_1bpp_graphic_to_block_offset_source(self):
+        source = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+                  [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0, 0, 1, 0, 0, 1],
+                  [0, 0, 1, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 0, 0, 1, 0, 0, 1, 0, 1, 0],
+                  [0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
+                  [0, 0, 0, 1, 1, 1, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+        target = Block()
+        target.from_list([0] * 8)
+        self.assertEqual(8, write_1bpp_graphic_to_block(source, target, 0, x=2, y=1, height=8))
+        self.assertListEqual(target.to_list(), [0b00000011,
+                                             0b01110000,
+                                             0b01001001,
+                                             0b11110000,
+                                             0b01001010,
+                                             0b11001000,
+                                             0b01110001,
+                                             0b00000001])
 
 
-def test_read_2bpp_graphic_from_block():
-    source = Block()
-    source.from_list([1, 2, 3,
-                      0b01010101,
-                      0b10111010,
-                      0b01100100,
-                      0b11001111,
-                      0b10100000,
-                      0b10111101,
-                      0b11100001,
-                      0b01101011,
-                      0b10110111,
-                      0b00000111,
-                      0b11111010,
-                      0b01111101,
-                      0b00110010,
-                      0b11101100,
-                      0b00110110,
-                      0b10111100])
-    target = [[0 for x in range(8)] for y in range(8)]
-    assert_equal(16, read_2bpp_graphic_from_block(target=target, source=source, offset=3, x=0, y=0, bit_offset=0))
-    assert_list_equal(target,
-                      [[2, 1, 2, 3, 2, 1, 2, 1],
-                       [2, 3, 1, 0, 2, 3, 2, 2],
-                       [3, 0, 3, 2, 2, 2, 0, 2],
-                       [1, 3, 3, 0, 2, 0, 2, 3],
-                       [1, 0, 1, 1, 0, 3, 3, 3],
-                       [1, 3, 3, 3, 3, 2, 1, 2],
-                       [2, 2, 3, 1, 2, 2, 1, 0],
-                       [2, 0, 3, 3, 2, 3, 1, 0]])
+    def test_write_1bpp_graphic_to_block_rectangular_short(self):
+        source = [[0, 0, 0, 0, 0, 0, 1, 1],
+                  [0, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 0, 1],
+                  [1, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 1, 0],
+                  [1, 1, 0, 0, 1, 0, 0, 0]]
+        target = Block()
+        target.from_list([0xeb] * 8)
+        target[0] = 42
+        self.assertEqual(6, write_1bpp_graphic_to_block(source, target, 2, x=0, y=0, height=6))
+        self.assertListEqual(target.to_list(), [42, 0xeb,
+                                             0b00000011,
+                                             0b01110000,
+                                             0b01001001,
+                                             0b11110000,
+                                             0b01001010,
+                                             0b11001000])
 
 
-def test_read_2bpp_graphic_from_block_offset_xy():
-    source = Block()
-    source.from_list([0b01010101,
-                      0b10111010,
-                      0b01100100,
-                      0b11001111,
-                      0b10100000,
-                      0b10111101,
-                      0b11100001,
-                      0b01101011,
-                      0b10110111,
-                      0b00000111,
-                      0b11111010,
-                      0b01111101,
-                      0b00110010,
-                      0b11101100,
-                      0b00110110,
-                      0b10111100, 5])
-    target = [[0 for x in range(10)] for y in range(10)]
-    assert_equal(16, read_2bpp_graphic_from_block(target=target, source=source, offset=0, x=2, y=1, bit_offset=0))
-    assert_list_equal(target,
-                      [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                       [0, 0, 2, 1, 2, 3, 2, 1, 2, 1],
-                       [0, 0, 2, 3, 1, 0, 2, 3, 2, 2],
-                       [0, 0, 3, 0, 3, 2, 2, 2, 0, 2],
-                       [0, 0, 1, 3, 3, 0, 2, 0, 2, 3],
-                       [0, 0, 1, 0, 1, 1, 0, 3, 3, 3],
-                       [0, 0, 1, 3, 3, 3, 3, 2, 1, 2],
-                       [0, 0, 2, 2, 3, 1, 2, 2, 1, 0],
-                       [0, 0, 2, 0, 3, 3, 2, 3, 1, 0],
-                       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+    def test_read_1bpp_graphic_from_block_rectangular_tall(self):
+        source = [[0, 0, 0, 0, 0, 0, 1, 1],
+                  [0, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 0, 1],
+                  [1, 1, 1, 1, 0, 0, 0, 0],
+                  [0, 1, 0, 0, 1, 0, 1, 0],
+                  [1, 1, 0, 0, 1, 0, 0, 0],
+                  [0, 1, 1, 1, 0, 0, 0, 1],
+                  [0, 0, 0, 0, 0, 0, 0, 1],
+                  [0, 0, 1, 0, 0, 0, 0, 0],
+                  [0, 0, 1, 1, 0, 0, 0, 0],
+                  [0, 0, 1, 0, 1, 0, 0, 0],
+                  [0, 0, 1, 0, 1, 0, 0, 0],
+                  [0, 1, 1, 0, 0, 0, 0, 0],
+                  [1, 1, 1, 0, 0, 0, 0, 0],
+                  [1, 1, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 1]]
+        target = Block()
+        target.from_list([42, 11, 99, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 112, 113, 114, 115, 116, 12, 21])
+        self.assertEqual(16, write_1bpp_graphic_to_block(source, target, 3, x=0, y=0, height=16))
+        self.assertListEqual(target.to_list(), [42, 11, 99,
+                                             0b00000011,
+                                             0b01110000,
+                                             0b01001001,
+                                             0b11110000,
+                                             0b01001010,
+                                             0b11001000,
+                                             0b01110001,
+                                             0b00000001,
+                                             0b00100000,
+                                             0b00110000,
+                                             0b00101000,
+                                             0b00101000,
+                                             0b01100000,
+                                             0b11100000,
+                                             0b11000000,
+                                             0b00000001,
+                                             12, 21])
 
 
-def test_write_2bpp_graphic_to_block():
-    source = [[2, 1, 2, 3, 2, 1, 2, 1],
-              [2, 3, 1, 0, 2, 3, 2, 2],
-              [3, 0, 3, 2, 2, 2, 0, 2],
-              [1, 3, 3, 0, 2, 0, 2, 3],
-              [1, 0, 1, 1, 0, 3, 3, 3],
-              [1, 3, 3, 3, 3, 2, 1, 2],
-              [2, 2, 3, 1, 2, 2, 1, 0],
-              [2, 0, 3, 3, 2, 3, 1, 0]]
-    target = Block()
-    target.from_list([0] * 16)
-    assert_equal(16, write_2bpp_graphic_to_block(source=source, target=target, offset=0, x=0, y=0, bit_offset=0))
-    assert_list_equal(target.to_list(),
-                      [0b01010101,
-                       0b10111010,
-                       0b01100100,
-                       0b11001111,
-                       0b10100000,
-                       0b10111101,
-                       0b11100001,
-                       0b01101011,
-                       0b10110111,
-                       0b00000111,
-                       0b11111010,
-                       0b01111101,
-                       0b00110010,
-                       0b11101100,
-                       0b00110110,
-                       0b10111100])
+    def test_read_2bpp_graphic_from_block(self):
+        source = Block()
+        source.from_list([1, 2, 3,
+                          0b01010101,
+                          0b10111010,
+                          0b01100100,
+                          0b11001111,
+                          0b10100000,
+                          0b10111101,
+                          0b11100001,
+                          0b01101011,
+                          0b10110111,
+                          0b00000111,
+                          0b11111010,
+                          0b01111101,
+                          0b00110010,
+                          0b11101100,
+                          0b00110110,
+                          0b10111100])
+        target = [[0 for x in range(8)] for y in range(8)]
+        self.assertEqual(16, read_2bpp_graphic_from_block(target=target, source=source, offset=3, x=0, y=0, bit_offset=0))
+        self.assertListEqual(target,
+                          [[2, 1, 2, 3, 2, 1, 2, 1],
+                           [2, 3, 1, 0, 2, 3, 2, 2],
+                           [3, 0, 3, 2, 2, 2, 0, 2],
+                           [1, 3, 3, 0, 2, 0, 2, 3],
+                           [1, 0, 1, 1, 0, 3, 3, 3],
+                           [1, 3, 3, 3, 3, 2, 1, 2],
+                           [2, 2, 3, 1, 2, 2, 1, 0],
+                           [2, 0, 3, 3, 2, 3, 1, 0]])
 
 
-def test_write_2bpp_graphic_to_block_offset_xy():
-    source = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-              [0, 0, 2, 1, 2, 3, 2, 1, 2, 1],
-              [0, 0, 2, 3, 1, 0, 2, 3, 2, 2],
-              [0, 0, 3, 0, 3, 2, 2, 2, 0, 2],
-              [0, 0, 1, 3, 3, 0, 2, 0, 2, 3],
-              [0, 0, 1, 0, 1, 1, 0, 3, 3, 3],
-              [0, 0, 1, 3, 3, 3, 3, 2, 1, 2],
-              [0, 0, 2, 2, 3, 1, 2, 2, 1, 0],
-              [0, 0, 2, 0, 3, 3, 2, 3, 1, 0],
-              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
-    target = Block()
-    target.from_list([0xff] * 18)
-    assert_equal(16, write_2bpp_graphic_to_block(source=source, target=target, offset=1, x=2, y=1, bit_offset=0))
-    assert_list_equal(target.to_list(),
-                      [0xff,
-                       0b01010101,
-                       0b10111010,
-                       0b01100100,
-                       0b11001111,
-                       0b10100000,
-                       0b10111101,
-                       0b11100001,
-                       0b01101011,
-                       0b10110111,
-                       0b00000111,
-                       0b11111010,
-                       0b01111101,
-                       0b00110010,
-                       0b11101100,
-                       0b00110110,
-                       0b10111100,
-                       0xff])
+    def test_read_2bpp_graphic_from_block_offset_xy(self):
+        source = Block()
+        source.from_list([0b01010101,
+                          0b10111010,
+                          0b01100100,
+                          0b11001111,
+                          0b10100000,
+                          0b10111101,
+                          0b11100001,
+                          0b01101011,
+                          0b10110111,
+                          0b00000111,
+                          0b11111010,
+                          0b01111101,
+                          0b00110010,
+                          0b11101100,
+                          0b00110110,
+                          0b10111100, 5])
+        target = [[0 for x in range(10)] for y in range(10)]
+        self.assertEqual(16, read_2bpp_graphic_from_block(target=target, source=source, offset=0, x=2, y=1, bit_offset=0))
+        self.assertListEqual(target,
+                          [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                           [0, 0, 2, 1, 2, 3, 2, 1, 2, 1],
+                           [0, 0, 2, 3, 1, 0, 2, 3, 2, 2],
+                           [0, 0, 3, 0, 3, 2, 2, 2, 0, 2],
+                           [0, 0, 1, 3, 3, 0, 2, 0, 2, 3],
+                           [0, 0, 1, 0, 1, 1, 0, 3, 3, 3],
+                           [0, 0, 1, 3, 3, 3, 3, 2, 1, 2],
+                           [0, 0, 2, 2, 3, 1, 2, 2, 1, 0],
+                           [0, 0, 2, 0, 3, 3, 2, 3, 1, 0],
+                           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
-def test_read_4bpp_graphic_from_block():
-    source = Block()
-    source.from_list([0b01010110,
-                      0b00001011,
-
-                      0b11001110,
-                      0b10010110,
-
-                      0b01110001,
-                      0b00111011,
-
-                      0b00001011,
-                      0b10011110,
-
-                      0b00011000,
-                      0b00000011,
-
-                      0b10000001,
-                      0b11101011,
-
-                      0b00000100,
-                      0b01000101,
-
-                      0b01010110,
-                      0b10001111,
-
-                      0b00101100,
-                      0b10110000,
-
-                      0b01010110,
-                      0b10110010,
-
-                      0b01010000,
-                      0b11000000,
-
-                      0b00111000,
-                      0b10010111,
-
-                      0b00101101,
-                      0b11111100,
-
-                      0b01111101,
-                      0b11101010,
-
-                      0b10101111,
-                      0b10110111,
-
-                      0b01100000,
-                      0b11101110])
-    target = [[0 for x in range(8)] for y in range(8)]
-    assert_equal(32, read_4bpp_graphic_from_block(target=target, source=source, offset=0, x=0, y=0, bit_offset=0))
-    assert_list_equal(target,
-                      [[8, 1, 12, 9, 6, 5, 3, 2],
-                       [11, 5, 8, 14, 1, 7, 15, 0],
-                       [8, 13, 3, 7, 2, 0, 2, 3],
-                       [10, 0, 4, 14, 7, 10, 11, 9],
-                       [8, 8, 12, 9, 13, 12, 2, 6],
-                       [11, 14, 14, 4, 14, 4, 10, 7],
-                       [12, 2, 12, 8, 4, 15, 12, 14],
-                       [10, 13, 12, 1, 10, 11, 11, 2]])
+    def test_write_2bpp_graphic_to_block(self):
+        source = [[2, 1, 2, 3, 2, 1, 2, 1],
+                  [2, 3, 1, 0, 2, 3, 2, 2],
+                  [3, 0, 3, 2, 2, 2, 0, 2],
+                  [1, 3, 3, 0, 2, 0, 2, 3],
+                  [1, 0, 1, 1, 0, 3, 3, 3],
+                  [1, 3, 3, 3, 3, 2, 1, 2],
+                  [2, 2, 3, 1, 2, 2, 1, 0],
+                  [2, 0, 3, 3, 2, 3, 1, 0]]
+        target = Block()
+        target.from_list([0] * 16)
+        self.assertEqual(16, write_2bpp_graphic_to_block(source=source, target=target, offset=0, x=0, y=0, bit_offset=0))
+        self.assertListEqual(target.to_list(),
+                          [0b01010101,
+                           0b10111010,
+                           0b01100100,
+                           0b11001111,
+                           0b10100000,
+                           0b10111101,
+                           0b11100001,
+                           0b01101011,
+                           0b10110111,
+                           0b00000111,
+                           0b11111010,
+                           0b01111101,
+                           0b00110010,
+                           0b11101100,
+                           0b00110110,
+                           0b10111100])
 
 
-def test_write_4bpp_graphic_to_block():
-    source = [[8, 1, 12, 9, 6, 5, 3, 2],
-              [11, 5, 8, 14, 1, 7, 15, 0],
-              [8, 13, 3, 7, 2, 0, 2, 3],
-              [10, 0, 4, 14, 7, 10, 11, 9],
-              [8, 8, 12, 9, 13, 12, 2, 6],
-              [11, 14, 14, 4, 14, 4, 10, 7],
-              [12, 2, 12, 8, 4, 15, 12, 14],
-              [10, 13, 12, 1, 10, 11, 11, 2]]
-    target = Block()
-    target.from_list([0] * 32)
-    assert_equal(32, write_4bpp_graphic_to_block(source=source, target=target, offset=0, x=0, y=0, bit_offset=0))
-    assert_list_equal(target.to_list(),
-                      [
-                          0b01010110,
+    def test_write_2bpp_graphic_to_block_offset_xy(self):
+        source = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 2, 1, 2, 3, 2, 1, 2, 1],
+                  [0, 0, 2, 3, 1, 0, 2, 3, 2, 2],
+                  [0, 0, 3, 0, 3, 2, 2, 2, 0, 2],
+                  [0, 0, 1, 3, 3, 0, 2, 0, 2, 3],
+                  [0, 0, 1, 0, 1, 1, 0, 3, 3, 3],
+                  [0, 0, 1, 3, 3, 3, 3, 2, 1, 2],
+                  [0, 0, 2, 2, 3, 1, 2, 2, 1, 0],
+                  [0, 0, 2, 0, 3, 3, 2, 3, 1, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+        target = Block()
+        target.from_list([0xff] * 18)
+        self.assertEqual(16, write_2bpp_graphic_to_block(source=source, target=target, offset=1, x=2, y=1, bit_offset=0))
+        self.assertListEqual(target.to_list(),
+                          [0xff,
+                           0b01010101,
+                           0b10111010,
+                           0b01100100,
+                           0b11001111,
+                           0b10100000,
+                           0b10111101,
+                           0b11100001,
+                           0b01101011,
+                           0b10110111,
+                           0b00000111,
+                           0b11111010,
+                           0b01111101,
+                           0b00110010,
+                           0b11101100,
+                           0b00110110,
+                           0b10111100,
+                           0xff])
+
+
+    def test_read_4bpp_graphic_from_block(self):
+        source = Block()
+        source.from_list([0b01010110,
                           0b00001011,
 
                           0b11001110,
@@ -480,5 +406,79 @@ def test_write_4bpp_graphic_to_block():
                           0b10110111,
 
                           0b01100000,
-                          0b11101110
-                      ])
+                          0b11101110])
+        target = [[0 for x in range(8)] for y in range(8)]
+        self.assertEqual(32, read_4bpp_graphic_from_block(target=target, source=source, offset=0, x=0, y=0, bit_offset=0))
+        self.assertListEqual(target,
+                          [[8, 1, 12, 9, 6, 5, 3, 2],
+                           [11, 5, 8, 14, 1, 7, 15, 0],
+                           [8, 13, 3, 7, 2, 0, 2, 3],
+                           [10, 0, 4, 14, 7, 10, 11, 9],
+                           [8, 8, 12, 9, 13, 12, 2, 6],
+                           [11, 14, 14, 4, 14, 4, 10, 7],
+                           [12, 2, 12, 8, 4, 15, 12, 14],
+                           [10, 13, 12, 1, 10, 11, 11, 2]])
+
+
+    def test_write_4bpp_graphic_to_block(self):
+        source = [[8, 1, 12, 9, 6, 5, 3, 2],
+                  [11, 5, 8, 14, 1, 7, 15, 0],
+                  [8, 13, 3, 7, 2, 0, 2, 3],
+                  [10, 0, 4, 14, 7, 10, 11, 9],
+                  [8, 8, 12, 9, 13, 12, 2, 6],
+                  [11, 14, 14, 4, 14, 4, 10, 7],
+                  [12, 2, 12, 8, 4, 15, 12, 14],
+                  [10, 13, 12, 1, 10, 11, 11, 2]]
+        target = Block()
+        target.from_list([0] * 32)
+        self.assertEqual(32, write_4bpp_graphic_to_block(source=source, target=target, offset=0, x=0, y=0, bit_offset=0))
+        self.assertListEqual(target.to_list(),
+                          [
+                              0b01010110,
+                              0b00001011,
+
+                              0b11001110,
+                              0b10010110,
+
+                              0b01110001,
+                              0b00111011,
+
+                              0b00001011,
+                              0b10011110,
+
+                              0b00011000,
+                              0b00000011,
+
+                              0b10000001,
+                              0b11101011,
+
+                              0b00000100,
+                              0b01000101,
+
+                              0b01010110,
+                              0b10001111,
+
+                              0b00101100,
+                              0b10110000,
+
+                              0b01010110,
+                              0b10110010,
+
+                              0b01010000,
+                              0b11000000,
+
+                              0b00111000,
+                              0b10010111,
+
+                              0b00101101,
+                              0b11111100,
+
+                              0b01111101,
+                              0b11101010,
+
+                              0b10101111,
+                              0b10110111,
+
+                              0b01100000,
+                              0b11101110
+                          ])

--- a/tests/util/eb/test_pointer.py
+++ b/tests/util/eb/test_pointer.py
@@ -1,44 +1,43 @@
-from nose.tools import assert_equal, assert_list_equal
-from nose.tools.nontrivial import raises
-
 from coilsnake.exceptions.common.exceptions import InvalidArgumentError
 from coilsnake.model.common.blocks import Block
 from coilsnake.util.eb.pointer import from_snes_address, write_asm_pointer, read_asm_pointer, to_snes_address
 
+from tests.coilsnake_test import BaseTestCase
 
-def test_from_snes_address():
-    assert_equal(from_snes_address(0xc00000), 0)
-    assert_equal(from_snes_address(0xcf1234), 0xf1234)
-    assert_equal(from_snes_address(0xeabc4f), 0x2abc4f)
-    assert_equal(from_snes_address(0xffffff), 0x3fffff)
-    assert_equal(from_snes_address(0x400000), 0x400000)
-    assert_equal(from_snes_address(0x4daa34), 0x4daa34)
-    assert_equal(from_snes_address(0x5fffff), 0x5fffff)
-
-
-@raises(InvalidArgumentError)
-def test_from_snes_address_negative():
-    from_snes_address(-1)
+class EbPointerUtilTestCase(BaseTestCase):
+    def test_from_snes_address(self):
+        self.assertEqual(from_snes_address(0xc00000), 0)
+        self.assertEqual(from_snes_address(0xcf1234), 0xf1234)
+        self.assertEqual(from_snes_address(0xeabc4f), 0x2abc4f)
+        self.assertEqual(from_snes_address(0xffffff), 0x3fffff)
+        self.assertEqual(from_snes_address(0x400000), 0x400000)
+        self.assertEqual(from_snes_address(0x4daa34), 0x4daa34)
+        self.assertEqual(from_snes_address(0x5fffff), 0x5fffff)
 
 
-def test_to_snes_address():
-    assert_equal(to_snes_address(0), 0xc00000)
-    assert_equal(to_snes_address(0xf1234), 0xcf1234)
-    assert_equal(to_snes_address(0x2abc4f), 0xeabc4f)
-    assert_equal(to_snes_address(0x3fffff), 0xffffff)
-    assert_equal(to_snes_address(0x400000), 0x400000)
-    assert_equal(to_snes_address(0x4daa34), 0x4daa34)
-    assert_equal(to_snes_address(0x5fffff), 0x5fffff)
+    def test_from_snes_address_negative(self):
+        with self.assertRaises(InvalidArgumentError):
+            from_snes_address(-1)
 
 
-def test_read_asm_pointer():
-    block = Block()
-    block.from_list([0xee, 0xee, 0x12, 0x34, 0xee, 0xee, 0xee, 0x56, 0x78])
-    assert_equal(read_asm_pointer(block, 1), 0x78563412)
+    def test_to_snes_address(self):
+        self.assertEqual(to_snes_address(0), 0xc00000)
+        self.assertEqual(to_snes_address(0xf1234), 0xcf1234)
+        self.assertEqual(to_snes_address(0x2abc4f), 0xeabc4f)
+        self.assertEqual(to_snes_address(0x3fffff), 0xffffff)
+        self.assertEqual(to_snes_address(0x400000), 0x400000)
+        self.assertEqual(to_snes_address(0x4daa34), 0x4daa34)
+        self.assertEqual(to_snes_address(0x5fffff), 0x5fffff)
 
 
-def test_write_asm_pointer():
-    block = Block()
-    block.from_list([0xee] * 9)
-    write_asm_pointer(block, 1, 0xabcdef12)
-    assert_list_equal(block.to_list(), [0xee, 0xee, 0x12, 0xef, 0xee, 0xee, 0xee, 0xcd, 0xab])
+    def test_read_asm_pointer(self):
+        block = Block()
+        block.from_list([0xee, 0xee, 0x12, 0x34, 0xee, 0xee, 0xee, 0x56, 0x78])
+        self.assertEqual(read_asm_pointer(block, 1), 0x78563412)
+
+
+    def test_write_asm_pointer(self):
+        block = Block()
+        block.from_list([0xee] * 9)
+        write_asm_pointer(block, 1, 0xabcdef12)
+        self.assertListEqual(block.to_list(), [0xee, 0xee, 0x12, 0xef, 0xee, 0xee, 0xee, 0xcd, 0xab])

--- a/tests/util/eb/test_text.py
+++ b/tests/util/eb/test_text.py
@@ -1,88 +1,88 @@
 # coding: utf-8
-from nose.tools import assert_list_equal
-from nose.tools.nontrivial import raises
-
 from coilsnake.util.eb.text import standard_text_to_block, CharacterSubstitutions, standard_text_to_byte_list
 from coilsnake.model.common.blocks import Block
 
-
-def test_standard_text_to_block():
-    b = Block()
-
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="Test", max_length=10)
-    assert_list_equal(b.to_list(), [132, 149, 163, 164, 0, 0, 0, 0, 0, 0])
-
-    b.from_list([0x66] * 10)
-    standard_text_to_block(block=b, offset=0, text="Test", max_length=10)
-    assert_list_equal(b.to_list(), [132, 149, 163, 164, 0, 0x66, 0x66, 0x66, 0x66, 0x66])
+from tests.coilsnake_test import BaseTestCase
 
 
-@raises(ValueError)
-def test_standard_text_to_block_too_long():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="12345678901", max_length=10)
+class EbTextTestCase(BaseTestCase):
+    def test_standard_text_to_block(self):
+        b = Block()
+
+        b.from_list([0] * 10)
+        standard_text_to_block(block=b, offset=0, text="Test", max_length=10)
+        self.assertListEqual(b.to_list(), [132, 149, 163, 164, 0, 0, 0, 0, 0, 0])
+
+        b.from_list([0x66] * 10)
+        standard_text_to_block(block=b, offset=0, text="Test", max_length=10)
+        self.assertListEqual(b.to_list(), [132, 149, 163, 164, 0, 0x66, 0x66, 0x66, 0x66, 0x66])
 
 
-def test_standard_text_to_block_with_brackets():
-    b = Block()
-
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[01 02 03 04]", max_length=10)
-    assert_list_equal(b.to_list(), [0x01, 0x02, 0x03, 0x04, 0, 0, 0, 0, 0, 0])
-
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[]", max_length=10)
-    assert_list_equal(b.to_list(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="Te[ab cd ef]st", max_length=10)
-    assert_list_equal(b.to_list(), [132, 149, 0xab, 0xcd, 0xef, 163, 164, 0, 0, 0])
+    def test_standard_text_to_block_too_long(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="12345678901", max_length=10)
 
 
-@raises(ValueError)
-def test_standard_text_to_block_with_brackets_not_two_digits():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[1 02 03 04]", max_length=10)
+    def test_standard_text_to_block_with_brackets(self):
+        b = Block()
+
+        b.from_list([0] * 10)
+        standard_text_to_block(block=b, offset=0, text="[01 02 03 04]", max_length=10)
+        self.assertListEqual(b.to_list(), [0x01, 0x02, 0x03, 0x04, 0, 0, 0, 0, 0, 0])
+
+        b.from_list([0] * 10)
+        standard_text_to_block(block=b, offset=0, text="[]", max_length=10)
+        self.assertListEqual(b.to_list(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+
+        b.from_list([0] * 10)
+        standard_text_to_block(block=b, offset=0, text="Te[ab cd ef]st", max_length=10)
+        self.assertListEqual(b.to_list(), [132, 149, 0xab, 0xcd, 0xef, 163, 164, 0, 0, 0])
 
 
-@raises(ValueError)
-def test_standard_text_to_block_with_brackets_not_hex():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[ag]", max_length=10)
+    def test_standard_text_to_block_with_brackets_not_two_digits(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="[1 02 03 04]", max_length=10)
 
 
-@raises(ValueError)
-def test_standard_text_to_block_with_brackets_not_ended_with_bracket():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[01 02 03", max_length=10)
+    def test_standard_text_to_block_with_brackets_not_hex(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="[ag]", max_length=10)
 
 
-@raises(ValueError)
-def test_standard_text_to_block_with_brackets_too_long():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="[01 02 03 04 05 06 07 08 09 0a 0b]", max_length=10)
+    def test_standard_text_to_block_with_brackets_not_ended_with_bracket(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="[01 02 03", max_length=10)
 
 
-@raises(ValueError)
-def test_standard_text_to_block_with_brackets_too_long2():
-    b = Block()
-    b.from_list([0] * 10)
-    standard_text_to_block(block=b, offset=0, text="abcd[01 02 03 04 05 06 07]", max_length=10)
+    def test_standard_text_to_block_with_brackets_too_long(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="[01 02 03 04 05 06 07 08 09 0a 0b]", max_length=10)
 
 
-def test_standard_text_to_byte_list_replacement():
-    CharacterSubstitutions.character_substitutions = {'A': 'B'}
-    assert_list_equal([114, 114, 115, 116, 114, 117, 118, 119, 114],
-                      standard_text_to_byte_list("ABCDAEFGA", 9))
+    def test_standard_text_to_block_with_brackets_too_long2(self):
+        b = Block()
+        b.from_list([0] * 10)
+        with self.assertRaises(ValueError):
+            standard_text_to_block(block=b, offset=0, text="abcd[01 02 03 04 05 06 07]", max_length=10)
 
 
-def test_standard_text_to_byte_list_replacement_unicode():
-    CharacterSubstitutions.character_substitutions = {'я': 'B'}
-    assert_list_equal([114, 114, 115, 116, 114, 117, 118, 119, 114],
-                      standard_text_to_byte_list("яBCDяEFGя", 9))
+    def test_standard_text_to_byte_list_replacement(self):
+        CharacterSubstitutions.character_substitutions = {'A': 'B'}
+        self.assertListEqual([114, 114, 115, 116, 114, 117, 118, 119, 114],
+                          standard_text_to_byte_list("ABCDAEFGA", 9))
+
+
+    def test_standard_text_to_byte_list_replacement_unicode(self):
+        CharacterSubstitutions.character_substitutions = {'я': 'B'}
+        self.assertListEqual([114, 114, 115, 116, 114, 117, 118, 119, 114],
+                          standard_text_to_byte_list("яBCDяEFGя", 9))


### PR DESCRIPTION
CoilSnake's unit tests were ported from the Python standard library module [`unittest`](https://docs.python.org/3/library/unittest.html) to [`nose`](https://nose.readthedocs.io/en/latest/) pretty early on, in b5e61b0fd5f172c30dfc1ea8831fe02beb38c2fd. Nose has received no commits in 10 years and has this written on its home page:

> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using [Nose2](https://github.com/nose-devs/nose2), [py.test](http://pytest.org/), or just plain unittest/unittest2.

So I didn't try installing nose or getting the existing test suite to work as-is, and decided to port it to one of the listed options.

Nose2 uses slightly different function names than the original Nose (`snake_case` names become `camelCase` names), and its [documentation](https://docs.nose2.io/en/latest/index.html#nose2-vs-pytest) and [maintainers](https://groups.google.com/a/nose2.io/g/discuss/c/kU6Uy0ugQfs/m/UoGP3etDDgAJ) generally recommend switching to other, more popular frameworks. Unittest is a bit verbose, but it's still a fairly mechanical translation from Nose, especially compared to what I've seen of pytest. pytest also has some support for [incrementally switching from a unittest-based project](https://docs.pytest.org/en/9.0.x/how-to/unittest.html) if desired. And unittest has the benefit that you don't need to install a third-party dependency. So I went with unittest.

Other changes:

* All checks for ROMs are now gated behind checks for the files existing, and the test is skipped otherwise.
* Some "abstract test cases," as in test cases that rely on inheritance to fill in a class member to run the test with, will skip the test when the field isn't found, instead of failing. There might have been a better way to solve this but 🤷
* Print statements in tests were removed
* A few bitrotted tests were replaced with better versions (the compression test now sets an upper bound on the compressed size of the data, instead of checking for a long-outdated exact size).

There are a few tests that are still failing or misbehaving in nontrivial ways:

* `test_getitem_slice` and `test_setitem_slice` in tests/model/common/test_blocks.py: appears to be a regression from #270, which added support for indexing with negative numbers in slices. It's not just that negative numbers were expected to not work; there's unintuitive behavior going on like `0:-1` becoming `0:len(x)-1` and grabbing a non-empty sequence.
* Various palette-related tests that expect 8 bits of precision to be preserved in color channels are failing. This behavior appears to have been changed 3 times; once in 4bf87377c37836f3830157e7c739e302eb366738 specifically for `EbColor.from_list`, as part of town map bug fixes in CoilSnake 2.3; once in 3c1f7324ac037a57fe63cb8545c27ead932963b8 specifically for `EbColor.from_yml_rep`, as a hack after [many image-related problem reports](https://forum.starmen.net/forum/Community/PKHack/CoilSnake-v1-0-Cool-Fish-Type-Edition/2117546) with CoilSnake 2.3; and once in #260 for all the rest of the functions, which made all the EbColor factory functions consistent by reducing everything to 5 bits on construction. It's *probably* safe to update the tests here, but I haven't convinced myself of it yet
* This isn't a failure necessarily, but EBP patching apparently must support "fixing" several "wrong" variants of the EarthBound ROM, and the tests for the fixing process require those "wrong" ROMs to be present in a specific folder. All we have of the ROMs are MD5 hashes (in the EBPatcher/CoilSnake [source code](https://github.com/pk-hack/CoilSnake/blob/346cfc753644bc3703b6fc4eaa0a5d6bdcb9bb4a/coilsnake/model/eb/blocks.py#L29-L38)) and CRC32 checksums (in the [BPS patches](https://github.com/Lyrositor/EBPatcher/tree/6288f33e2528dbd16632c302ac9b589c95fb0fa9/patches) from very old versions of EBPatcher). Running this test properly will probably require brute forcing all of the variant ROMs, which is probably easier for some of them than others... the wrong4 and wrong6 patches are huge.
* The test runner also diagnosed a file handle leak in the project loading code, probably related to this attempt to support calling the same method with two very different inputs: https://github.com/pk-hack/CoilSnake/blob/346cfc753644bc3703b6fc4eaa0a5d6bdcb9bb4a/coilsnake/util/common/project.py#L59

Tests can be run using `python -m unittest discover -s tests`. Marked as a draft for now because of the above issues, and because I haven't updated DEVELOPMENT.md with documentation, or removed references to Nose in setup.py.